### PR TITLE
Replace winapi with windows-sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 /.idea
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ tempfile = "3.3.0"
 wayland-client = {version = "0.29", features = ["use_system_lib"], default_features = false}
 x11-dl = "2.19.1"
 
-[target.'cfg(target_os = "windows")'.dependencies.winapi]
-version = "0.3.9"
-features = ["windef", "wingdi", "winuser"]
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.42.0"
+features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,9 +1,12 @@
 use crate::{GraphicsContextImpl, SoftBufferError};
 use raw_window_handle::{HasRawWindowHandle, Win32WindowHandle};
 use std::os::raw::c_int;
-use winapi::shared::windef::{HDC, HWND};
-use winapi::um::wingdi::{StretchDIBits, BITMAPINFOHEADER, BI_BITFIELDS, RGBQUAD};
-use winapi::um::winuser::{GetDC, ValidateRect};
+
+use windows_sys::Win32::Foundation::HWND;
+use windows_sys::Win32::Graphics::Gdi::{
+    StretchDIBits, BITMAPINFOHEADER, BI_BITFIELDS, RGBQUAD, HDC,
+    ValidateRect, GetDC, SRCCOPY, DIB_RGB_COLORS,
+};
 
 pub struct Win32Impl {
     window: HWND,
@@ -22,7 +25,7 @@ impl Win32Impl {
     pub unsafe fn new<W: HasRawWindowHandle>(handle: &Win32WindowHandle) -> Result<Self, crate::SoftBufferError<W>> {
         let dc = GetDC(handle.hwnd as HWND);
 
-        if dc.is_null(){
+        if dc == 0 {
             return Err(SoftBufferError::PlatformError(Some("Device Context is null".into()), None));
         }
 
@@ -61,8 +64,8 @@ impl GraphicsContextImpl for Win32Impl {
             height as c_int,
             std::mem::transmute(buffer.as_ptr()),
             std::mem::transmute(&bitmap_info),
-            winapi::um::wingdi::DIB_RGB_COLORS,
-            winapi::um::wingdi::SRCCOPY,
+            DIB_RGB_COLORS,
+            SRCCOPY,
         );
 
         ValidateRect(self.window, std::ptr::null_mut());


### PR DESCRIPTION
The Rust ecosystem as a whole is moving away from `winapi` and towards `windows-sys`, up to and including `winit`. This PR changes `winapi` for `windows-sys`.

Closes #26 