### PR TITLE
x11: Implement image transfer using the MIT-SHM extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60.0"
 default = ["x11", "wayland", "wayland-dlopen"]
 wayland = ["wayland-backend", "wayland-client", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
-x11 = ["bytemuck", "x11rb", "x11-dl"]
+x11 = ["bytemuck", "nix", "x11rb", "x11-dl"]
 
 [dependencies]
 thiserror = "1.0.30"
@@ -30,7 +30,7 @@ wayland-client = { version = "0.30.0", optional = true }
 wayland-sys = "0.30.0"
 bytemuck = { version = "1.12.3", optional = true }
 x11-dl = { version  = "2.19.1", optional = true }
-x11rb = { version = "0.11.0", features = ["allow-unsafe-code", "dl-libxcb"], optional = true }
+x11rb = { version = "0.11.0", features = ["allow-unsafe-code", "dl-libxcb", "shm"], optional = true }
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox", target_os = "linux", target_os = "freebsd"))))'.dependencies]
 fastrand = { version = "1.8.0", optional = true }


### PR DESCRIPTION
This PR implements image transfer using the MIT-SHM extension, allowing us to avoid image transfers over the wire.

~~At the moment I can't test this on my machine, as the x11-dl crate has a bug that prevents it from loading the MIT-SHM extension (https://github.com/AltF02/x11-rs/pull/164).~~ Circumvented this by moving to `x11rb`.

Closes https://github.com/rust-windowing/softbuffer/issues/38

(This is a port of rust-windowing/swbuf#23 to the new repository)