### PR TITLE
Update to stable wayland-rs 0.30, specify `rust-version`, rename `SwBufError` back to `SoftBufferError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ log = "0.4.17"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 nix = { version = "0.26.1", optional = true }
-wayland-backend = { version = "0.1.0-beta.14", features = ["client_system"], optional = true }
-wayland-client = { version = "0.30.0-beta.14", optional = true }
+wayland-backend = { version = "0.1.0", features = ["client_system"], optional = true }
+wayland-client = { version = "0.30.0", optional = true }
 wayland-sys = "0.30.0"
 bytemuck = { version = "1.12.3", optional = true }
 x11-dl = { version  = "2.19.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rust-windowing/softbuffer"
 keywords = ["framebuffer", "windowing"]
 categories = ["game-development", "graphics", "gui", "multimedia", "rendering"]
 exclude = ["examples"]
+rust-version = "1.60.0"
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen"]

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,4 +1,4 @@
-use crate::SwBufError;
+use crate::SoftBufferError;
 use core_graphics::base::{
     kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault,
 };
@@ -19,7 +19,7 @@ pub struct CGImpl {
 }
 
 impl CGImpl {
-    pub unsafe fn new(handle: AppKitWindowHandle) -> Result<Self, SwBufError> {
+    pub unsafe fn new(handle: AppKitWindowHandle) -> Result<Self, SoftBufferError> {
         let window = handle.ns_window as id;
         let view = handle.ns_view as id;
         let layer = CALayer::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum SwBufError {
+pub enum SoftBufferError {
     #[error(
         "The provided window returned an unsupported platform: {human_readable_window_platform_name}, {human_readable_display_platform_name}."
     )]
@@ -29,10 +29,10 @@ pub enum SwBufError {
 pub(crate) fn unwrap<T, E: std::error::Error + 'static>(
     res: Result<T, E>,
     str: &str,
-) -> Result<T, SwBufError> {
+) -> Result<T, SoftBufferError> {
     match res {
         Ok(t) => Ok(t),
-        Err(e) => Err(SwBufError::PlatformError(
+        Err(e) => Err(SoftBufferError::PlatformError(
             Some(str.into()),
             Some(Box::new(e)),
         )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod x11;
 
 mod error;
 
-pub use error::SwBufError;
+pub use error::SoftBufferError;
 
 use raw_window_handle::{
     HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
@@ -90,7 +90,7 @@ impl GraphicsContext {
     pub unsafe fn new<W: HasRawWindowHandle, D: HasRawDisplayHandle>(
         window: &W,
         display: &D,
-    ) -> Result<Self, SwBufError> {
+    ) -> Result<Self, SoftBufferError> {
         unsafe { Self::from_raw(window.raw_window_handle(), display.raw_display_handle()) }
     }
 
@@ -103,7 +103,7 @@ impl GraphicsContext {
     pub unsafe fn from_raw(
         raw_window_handle: RawWindowHandle,
         raw_display_handle: RawDisplayHandle,
-    ) -> Result<Self, SwBufError> {
+    ) -> Result<Self, SoftBufferError> {
         let imple: Dispatch = match (raw_window_handle, raw_display_handle) {
             #[cfg(all(feature = "x11", any(target_os = "linux", target_os = "freebsd")))]
             (
@@ -141,7 +141,7 @@ impl GraphicsContext {
                 Dispatch::Orbital(orbital::OrbitalImpl::new(orbital_handle)?)
             }
             (unimplemented_window_handle, unimplemented_display_handle) => {
-                return Err(SwBufError::UnsupportedPlatform {
+                return Err(SoftBufferError::UnsupportedPlatform {
                     human_readable_window_platform_name: window_handle_type_name(
                         &unimplemented_window_handle,
                     ),

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -1,7 +1,7 @@
 use raw_window_handle::OrbitalWindowHandle;
 use std::{cmp, slice, str};
 
-use crate::SwBufError;
+use crate::SoftBufferError;
 
 struct OrbitalMap {
     address: usize,
@@ -45,7 +45,7 @@ pub struct OrbitalImpl {
 }
 
 impl OrbitalImpl {
-    pub fn new(handle: OrbitalWindowHandle) -> Result<Self, SwBufError> {
+    pub fn new(handle: OrbitalWindowHandle) -> Result<Self, SoftBufferError> {
         Ok(Self { handle })
     }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::unwrap, SwBufError};
+use crate::{error::unwrap, SoftBufferError};
 use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle};
 use std::collections::VecDeque;
 use wayland_client::{
@@ -26,7 +26,7 @@ impl WaylandImpl {
     pub unsafe fn new(
         window_handle: WaylandWindowHandle,
         display_handle: WaylandDisplayHandle,
-    ) -> Result<Self, SwBufError> {
+    ) -> Result<Self, SoftBufferError> {
         // SAFETY: Ensured by user
         let backend = unsafe { Backend::from_foreign_display(display_handle.display as *mut _) };
         let conn = Connection::from_backend(backend);

--- a/src/web.rs
+++ b/src/web.rs
@@ -5,7 +5,7 @@ use web_sys::CanvasRenderingContext2d;
 use web_sys::HtmlCanvasElement;
 use web_sys::ImageData;
 
-use crate::SwBufError;
+use crate::SoftBufferError;
 
 pub struct WebImpl {
     canvas: HtmlCanvasElement,
@@ -13,17 +13,17 @@ pub struct WebImpl {
 }
 
 impl WebImpl {
-    pub fn new(handle: WebWindowHandle) -> Result<Self, SwBufError> {
+    pub fn new(handle: WebWindowHandle) -> Result<Self, SoftBufferError> {
         let canvas: HtmlCanvasElement = web_sys::window()
             .ok_or_else(|| {
-                SwBufError::PlatformError(
+                SoftBufferError::PlatformError(
                     Some("`window` is not present in this runtime".into()),
                     None,
                 )
             })?
             .document()
             .ok_or_else(|| {
-                SwBufError::PlatformError(
+                SoftBufferError::PlatformError(
                     Some("`document` is not present in this runtime".into()),
                     None,
                 )
@@ -32,7 +32,10 @@ impl WebImpl {
             // `querySelector` only throws an error if the selector is invalid.
             .unwrap()
             .ok_or_else(|| {
-                SwBufError::PlatformError(Some("No canvas found with the given id".into()), None)
+                SoftBufferError::PlatformError(
+                    Some("No canvas found with the given id".into()),
+                    None,
+                )
             })?
             // We already made sure this was a canvas in `querySelector`.
             .unchecked_into();
@@ -40,13 +43,13 @@ impl WebImpl {
         let ctx = canvas
         .get_context("2d")
         .map_err(|_| {
-            SwBufError::PlatformError(
+            SoftBufferError::PlatformError(
                 Some("Canvas already controlled using `OffscreenCanvas`".into()),
                 None,
             )
         })?
         .ok_or_else(|| {
-            SwBufError::PlatformError(
+            SoftBufferError::PlatformError(
                 Some("A canvas context other than `CanvasRenderingContext2d` was already created".into()),
                 None,
             )

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -2,7 +2,7 @@
 //!
 //! This module converts the input buffer into a bitmap and then stretches it to the window.
 
-use crate::SwBufError;
+use crate::SoftBufferError;
 use raw_window_handle::Win32WindowHandle;
 
 use std::io;
@@ -37,10 +37,10 @@ impl Win32Impl {
     /// # Safety
     ///
     /// The `Win32WindowHandle` must be a valid window handle.
-    pub unsafe fn new(handle: &Win32WindowHandle) -> Result<Self, crate::SwBufError> {
+    pub unsafe fn new(handle: &Win32WindowHandle) -> Result<Self, crate::SoftBufferError> {
         // It is valid for the window handle to be null here. Error out if it is.
         if handle.hwnd.is_null() {
-            return Err(SwBufError::IncompleteWindowHandle);
+            return Err(SoftBufferError::IncompleteWindowHandle);
         }
 
         // Get the handle to the device context.
@@ -50,7 +50,7 @@ impl Win32Impl {
 
         // GetDC returns null if there is a platform error.
         if dc == 0 {
-            return Err(SwBufError::PlatformError(
+            return Err(SoftBufferError::PlatformError(
                 Some("Device Context is null".into()),
                 Some(Box::new(io::Error::last_os_error())),
             ));


### PR DESCRIPTION
Wayland-rs 0.30 is released now. I also remembered we should add a `rust-version` to the manifest. And it seems this error name is the last thing that's left from the "swbuf" name.