### PR TITLE
chore: Alphabetize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,16 @@ wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["bytemuck", "x11rb", "x11-dl"]
 
 [dependencies]
-thiserror = "1.0.30"
-raw-window-handle = "0.5.0"
 log = "0.4.17"
+raw-window-handle = "0.5.0"
+thiserror = "1.0.30"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
+bytemuck = { version = "1.12.3", optional = true }
 nix = { version = "0.26.1", optional = true }
 wayland-backend = { version = "0.1.0", features = ["client_system"], optional = true }
 wayland-client = { version = "0.30.0", optional = true }
 wayland-sys = "0.30.0"
-bytemuck = { version = "1.12.3", optional = true }
 x11-dl = { version  = "2.19.1", optional = true }
 x11rb = { version = "0.11.0", features = ["allow-unsafe-code", "dl-libxcb"], optional = true }
 


### PR DESCRIPTION
This PR alphabetizes the dependencies in `Cargo.toml` so that `cargo add` works properly.