### PR TITLE
Owned pixel buffer for no-copy presentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ jobs:
     - name: Check Formatting
       run: cargo +stable fmt --all -- --check
 
+  miri-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: nightly
+        components: miri
+    - name: Run tests with miri
+      run: cargo +nightly miri test
+
   tests:
     name: Tests
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ version = "0.42.0"
 features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
+bytemuck = { version = "1.12.3", features = ["extern_crate_alloc"] }
 cocoa = "0.24.0"
 core-graphics = "0.22.3"
 foreign-types = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.60.0"
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen"]
-wayland = ["wayland-backend", "wayland-client", "nix", "fastrand"]
+wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["bytemuck", "nix", "x11rb", "x11-dl"]
 
@@ -25,6 +25,7 @@ thiserror = "1.0.30"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
 bytemuck = { version = "1.12.3", optional = true }
+memmap2 = { version = "0.5.8", optional = true }
 nix = { version = "0.26.1", optional = true }
 wayland-backend = { version = "0.1.0", features = ["client_system"], optional = true }
 wayland-client = { version = "0.30.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For now, the priority for new platforms is:
 Example
 ==
 ```rust,no_run
+use std::num::NonZeroU32;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -72,7 +73,12 @@ fn main() {
                     let size = window.inner_size();
                     (size.width, size.height)
                 };
-                surface.resize(width, height).unwrap();
+                surface
+                    .resize(
+                        NonZeroU32::new(width).unwrap(),
+                        NonZeroU32::new(height).unwrap(),
+                    )
+                    .unwrap();
 
                 let mut buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fn main() {
                 };
                 surface.resize(width, height).unwrap();
 
-                let buffer = surface.buffer_mut().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {
                     let y = index / width;
                     let x = index % width;
@@ -85,7 +85,7 @@ fn main() {
                     buffer[index as usize] = blue | (green << 8) | (red << 16);
                 }
 
-		surface.present().unwrap();
+		buffer.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/README.md
+++ b/README.md
@@ -72,21 +72,20 @@ fn main() {
                     let size = window.inner_size();
                     (size.width, size.height)
                 };
-                let buffer = (0..((width * height) as usize))
-                    .map(|index| {
-                        let y = index / (width as usize);
-                        let x = index % (width as usize);
-                        let red = x % 255;
-                        let green = y % 255;
-                        let blue = (x * y) % 255;
+                surface.resize(width, height);
 
-                        let color = blue | (green << 8) | (red << 16);
+                let buffer = surface.buffer_mut();
+                for index in 0..(width * height) {
+                    let y = index / width;
+                    let x = index % width;
+                    let red = x % 255;
+                    let green = y % 255;
+                    let blue = (x * y) % 255;
 
-                        color as u32
-                    })
-                    .collect::<Vec<_>>();
+                    buffer[index as usize] = blue | (green << 8) | (red << 16);
+                }
 
-                surface.set_buffer(&buffer, width as u16, height as u16);
+		surface.present();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ fn main() {
                     let size = window.inner_size();
                     (size.width, size.height)
                 };
-                surface.resize(width, height);
+                surface.resize(width, height).unwrap();
 
-                let buffer = surface.buffer_mut();
+                let buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {
                     let y = index / width;
                     let x = index % width;
@@ -85,7 +85,7 @@ fn main() {
                     buffer[index as usize] = blue | (green << 8) | (red << 16);
                 }
 
-		surface.present();
+		surface.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -2,6 +2,7 @@ use instant::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 use std::f64::consts::PI;
+use std::num::NonZeroU32;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -49,7 +50,12 @@ fn main() {
 
                 let frame = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
 
-                surface.resize(width, height).unwrap();
+                surface
+                    .resize(
+                        NonZeroU32::new(width).unwrap(),
+                        NonZeroU32::new(height).unwrap(),
+                    )
+                    .unwrap();
                 let mut buffer = surface.buffer_mut().unwrap();
                 buffer.copy_from_slice(frame);
                 buffer.present().unwrap();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -49,8 +49,8 @@ fn main() {
 
                 let frame = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
 
-                surface.resize(width, height);
-                surface.buffer_mut().copy_from_slice(frame);
+                surface.resize(width, height).unwrap();
+                surface.buffer_mut().unwrap().copy_from_slice(frame);
                 surface.present().unwrap();
             }
             Event::MainEventsCleared => {

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -51,7 +51,7 @@ fn main() {
 
                 surface.resize(width, height);
                 surface.buffer_mut().copy_from_slice(frame);
-                surface.present();
+                surface.present().unwrap();
             }
             Event::MainEventsCleared => {
                 window.request_redraw();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -47,8 +47,11 @@ fn main() {
                     frames = pre_render_frames(width as usize, height as usize);
                 };
 
-                let buffer = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
-                surface.set_buffer(buffer.as_slice(), width as u16, height as u16);
+                let frame = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
+
+                surface.resize(width, height);
+                surface.buffer_mut().copy_from_slice(frame);
+                surface.present();
             }
             Event::MainEventsCleared => {
                 window.request_redraw();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -50,8 +50,9 @@ fn main() {
                 let frame = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
 
                 surface.resize(width, height).unwrap();
-                surface.buffer_mut().unwrap().copy_from_slice(frame);
-                surface.present().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
+                buffer.copy_from_slice(frame);
+                buffer.present().unwrap();
             }
             Event::MainEventsCleared => {
                 window.request_redraw();

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -1,4 +1,5 @@
 use image::GenericImageView;
+use std::num::NonZeroU32;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -35,7 +36,12 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                surface.resize(fruit.width(), fruit.height()).unwrap();
+                surface
+                    .resize(
+                        NonZeroU32::new(fruit.width()).unwrap(),
+                        NonZeroU32::new(fruit.height()).unwrap(),
+                    )
+                    .unwrap();
 
                 let mut buffer = surface.buffer_mut().unwrap();
                 let width = fruit.width() as usize;

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -6,16 +6,6 @@ use winit::window::WindowBuilder;
 fn main() {
     //see fruit.jpg.license for the license of fruit.jpg
     let fruit = image::load_from_memory(include_bytes!("fruit.jpg")).unwrap();
-    let buffer = fruit
-        .pixels()
-        .map(|(_x, _y, pixel)| {
-            let red = pixel.0[0] as u32;
-            let green = pixel.0[1] as u32;
-            let blue = pixel.0[2] as u32;
-
-            blue | (green << 8) | (red << 16)
-        })
-        .collect::<Vec<_>>();
 
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new()
@@ -45,7 +35,20 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                surface.set_buffer(&buffer, fruit.width() as u16, fruit.height() as u16);
+                surface.resize(fruit.width(), fruit.height());
+
+                let buffer = surface.buffer_mut();
+                let width = fruit.width() as usize;
+                for (x, y, pixel) in fruit.pixels() {
+                    let red = pixel.0[0] as u32;
+                    let green = pixel.0[1] as u32;
+                    let blue = pixel.0[2] as u32;
+
+                    let color = blue | (green << 8) | (red << 16);
+                    buffer[y as usize * width + x as usize] = color;
+                }
+
+                surface.present();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -35,9 +35,9 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                surface.resize(fruit.width(), fruit.height());
+                surface.resize(fruit.width(), fruit.height()).unwrap();
 
-                let buffer = surface.buffer_mut();
+                let buffer = surface.buffer_mut().unwrap();
                 let width = fruit.width() as usize;
                 for (x, y, pixel) in fruit.pixels() {
                     let red = pixel.0[0] as u32;

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -48,7 +48,7 @@ fn main() {
                     buffer[y as usize * width + x as usize] = color;
                 }
 
-                surface.present();
+                surface.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -37,7 +37,7 @@ fn main() {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
                 surface.resize(fruit.width(), fruit.height()).unwrap();
 
-                let buffer = surface.buffer_mut().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
                 let width = fruit.width() as usize;
                 for (x, y, pixel) in fruit.pixels() {
                     let red = pixel.0[0] as u32;
@@ -48,7 +48,7 @@ fn main() {
                     buffer[y as usize * width + x as usize] = color;
                 }
 
-                surface.present().unwrap();
+                buffer.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/libxcb.rs
+++ b/examples/libxcb.rs
@@ -99,9 +99,9 @@ mod example {
                 Event::Expose(_) => {
                     // Draw a width x height red rectangle.
                     surface.resize(width.into(), height.into()).unwrap();
-                    let buffer = surface.buffer_mut().unwrap();
+                    let mut buffer = surface.buffer_mut().unwrap();
                     buffer.fill(RED);
-                    surface.present().unwrap();
+                    buffer.present().unwrap();
                 }
                 Event::ConfigureNotify(configure_notify) => {
                     width = configure_notify.width;

--- a/examples/libxcb.rs
+++ b/examples/libxcb.rs
@@ -101,7 +101,7 @@ mod example {
                     surface.resize(width.into(), height.into());
                     let buffer = surface.buffer_mut();
                     buffer.fill(RED);
-                    surface.present();
+                    surface.present().unwrap();
                 }
                 Event::ConfigureNotify(configure_notify) => {
                     width = configure_notify.width;

--- a/examples/libxcb.rs
+++ b/examples/libxcb.rs
@@ -3,6 +3,7 @@
 #[cfg(all(feature = "x11", any(target_os = "linux", target_os = "freebsd")))]
 mod example {
     use raw_window_handle::{RawDisplayHandle, RawWindowHandle, XcbDisplayHandle, XcbWindowHandle};
+    use std::num::NonZeroU32;
     use x11rb::{
         connection::Connection,
         protocol::{
@@ -98,7 +99,12 @@ mod example {
             match event {
                 Event::Expose(_) => {
                     // Draw a width x height red rectangle.
-                    surface.resize(width.into(), height.into()).unwrap();
+                    surface
+                        .resize(
+                            NonZeroU32::new(width.into()).unwrap(),
+                            NonZeroU32::new(height.into()).unwrap(),
+                        )
+                        .unwrap();
                     let mut buffer = surface.buffer_mut().unwrap();
                     buffer.fill(RED);
                     buffer.present().unwrap();

--- a/examples/libxcb.rs
+++ b/examples/libxcb.rs
@@ -12,6 +12,8 @@ mod example {
         xcb_ffi::XCBConnection,
     };
 
+    const RED: u32 = 255 << 16;
+
     pub(crate) fn run() {
         // Create a new XCB connection
         let (conn, screen) = XCBConnection::connect(None).expect("Failed to connect to X server");
@@ -96,13 +98,10 @@ mod example {
             match event {
                 Event::Expose(_) => {
                     // Draw a width x height red rectangle.
-                    let red = 255 << 16;
-                    let source = std::iter::repeat(red)
-                        .take((width as usize * height as usize) as _)
-                        .collect::<Vec<_>>();
-
-                    // Draw the buffer.
-                    surface.set_buffer(&source, width, height);
+                    surface.resize(width.into(), height.into());
+                    let buffer = surface.buffer_mut();
+                    buffer.fill(RED);
+                    surface.present();
                 }
                 Event::ConfigureNotify(configure_notify) => {
                     width = configure_notify.width;

--- a/examples/libxcb.rs
+++ b/examples/libxcb.rs
@@ -98,8 +98,8 @@ mod example {
             match event {
                 Event::Expose(_) => {
                     // Draw a width x height red rectangle.
-                    surface.resize(width.into(), height.into());
-                    let buffer = surface.buffer_mut();
+                    surface.resize(width.into(), height.into()).unwrap();
+                    let buffer = surface.buffer_mut().unwrap();
                     buffer.fill(RED);
                     surface.present().unwrap();
                 }

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -57,7 +58,12 @@ fn main() {
                 };
 
                 // Resize surface if needed
-                surface.resize(width, height).unwrap();
+                surface
+                    .resize(
+                        NonZeroU32::new(width).unwrap(),
+                        NonZeroU32::new(height).unwrap(),
+                    )
+                    .unwrap();
 
                 // Draw something in the window
                 let mut buffer = surface.buffer_mut().unwrap();

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -43,7 +43,6 @@ fn main() {
     let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
     let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
 
-    let mut buffer = Vec::new();
     let mut flag = false;
 
     event_loop.run(move |event, _, control_flow| {
@@ -54,19 +53,16 @@ fn main() {
                 // Grab the window's client area dimensions
                 let (width, height) = {
                     let size = window.inner_size();
-                    (size.width as usize, size.height as usize)
+                    (size.width, size.height)
                 };
 
-                // Resize the off-screen buffer if the window size has changed
-                if buffer.len() != width * height {
-                    buffer.resize(width * height, 0);
-                }
+                // Resize surface if needed
+                surface.resize(width, height);
 
-                // Draw something in the offscreen buffer
-                redraw(&mut buffer, width, height, flag);
-
-                // Blit the offscreen buffer to the window's client area
-                surface.set_buffer(&buffer, width as u16, height as u16);
+                // Draw something in the window
+                let buffer = surface.buffer_mut();
+                redraw(buffer, width as usize, height as usize, flag);
+                surface.present();
             }
 
             Event::WindowEvent {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -62,7 +62,7 @@ fn main() {
                 // Draw something in the window
                 let buffer = surface.buffer_mut();
                 redraw(buffer, width as usize, height as usize, flag);
-                surface.present();
+                surface.present().unwrap();
             }
 
             Event::WindowEvent {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -60,9 +60,9 @@ fn main() {
                 surface.resize(width, height).unwrap();
 
                 // Draw something in the window
-                let buffer = surface.buffer_mut().unwrap();
-                redraw(buffer, width as usize, height as usize, flag);
-                surface.present().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
+                redraw(&mut buffer, width as usize, height as usize, flag);
+                buffer.present().unwrap();
             }
 
             Event::WindowEvent {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -57,10 +57,10 @@ fn main() {
                 };
 
                 // Resize surface if needed
-                surface.resize(width, height);
+                surface.resize(width, height).unwrap();
 
                 // Draw something in the window
-                let buffer = surface.buffer_mut();
+                let buffer = surface.buffer_mut().unwrap();
                 redraw(buffer, width as usize, height as usize, flag);
                 surface.present().unwrap();
             }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -33,7 +34,12 @@ fn main() {
                     (size.width, size.height)
                 };
 
-                surface.resize(width, height).unwrap();
+                surface
+                    .resize(
+                        NonZeroU32::new(width).unwrap(),
+                        NonZeroU32::new(height).unwrap(),
+                    )
+                    .unwrap();
 
                 let mut buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -46,7 +46,7 @@ fn main() {
                     buffer[index as usize] = blue | (green << 8) | (red << 16);
                 }
 
-                surface.present();
+                surface.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -33,9 +33,9 @@ fn main() {
                     (size.width, size.height)
                 };
 
-                surface.resize(width, height);
+                surface.resize(width, height).unwrap();
 
-                let buffer = surface.buffer_mut();
+                let buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {
                     let y = index / width;
                     let x = index % width;

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -35,7 +35,7 @@ fn main() {
 
                 surface.resize(width, height).unwrap();
 
-                let buffer = surface.buffer_mut().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
                 for index in 0..(width * height) {
                     let y = index / width;
                     let x = index % width;
@@ -46,7 +46,7 @@ fn main() {
                     buffer[index as usize] = blue | (green << 8) | (red << 16);
                 }
 
-                surface.present().unwrap();
+                buffer.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -32,21 +32,21 @@ fn main() {
                     let size = window.inner_size();
                     (size.width, size.height)
                 };
-                let buffer = (0..((width * height) as usize))
-                    .map(|index| {
-                        let y = index / (width as usize);
-                        let x = index % (width as usize);
-                        let red = x % 255;
-                        let green = y % 255;
-                        let blue = (x * y) % 255;
 
-                        let color = blue | (green << 8) | (red << 16);
+                surface.resize(width, height);
 
-                        color as u32
-                    })
-                    .collect::<Vec<_>>();
+                let buffer = surface.buffer_mut();
+                for index in 0..(width * height) {
+                    let y = index as u32 / width;
+                    let x = index as u32 % width;
+                    let red = x % 255;
+                    let green = y % 255;
+                    let blue = (x * y) % 255;
 
-                surface.set_buffer(&buffer, width as u16, height as u16);
+                    buffer[index as usize] = blue | (green << 8) | (red << 16);
+                }
+
+                surface.present();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -37,8 +37,8 @@ fn main() {
 
                 let buffer = surface.buffer_mut();
                 for index in 0..(width * height) {
-                    let y = index as u32 / width;
-                    let x = index as u32 % width;
+                    let y = index / width;
+                    let x = index % width;
                     let red = x % 255;
                     let green = y % 255;
                     let blue = (x * y) % 255;

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -32,7 +33,10 @@ fn main() {
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
                 surface
-                    .resize(BUFFER_WIDTH as u32, BUFFER_HEIGHT as u32)
+                    .resize(
+                        NonZeroU32::new(BUFFER_WIDTH as u32).unwrap(),
+                        NonZeroU32::new(BUFFER_HEIGHT as u32).unwrap(),
+                    )
                     .unwrap();
 
                 let mut buffer = surface.buffer_mut().unwrap();

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -45,7 +45,7 @@ fn main() {
                     }
                 }
 
-                surface.present();
+                surface.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -31,21 +31,21 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                let buffer = (0..(BUFFER_WIDTH * BUFFER_HEIGHT))
-                    .map(|index| {
-                        let y = index / BUFFER_WIDTH;
-                        let x = index % BUFFER_WIDTH;
-                        let red = x % 255;
-                        let green = y % 255;
-                        let blue = (x * y) % 255;
+                surface.resize(BUFFER_WIDTH as u32, BUFFER_HEIGHT as u32);
+
+                let buffer = surface.buffer_mut();
+                for y in 0..BUFFER_HEIGHT {
+                    for x in 0..BUFFER_WIDTH {
+                        let red = x as u32 % 255;
+                        let green = y as u32 % 255;
+                        let blue = (x as u32 * y as u32) % 255;
 
                         let color = blue | (green << 8) | (red << 16);
+                        buffer[y * BUFFER_WIDTH + x] = color;
+                    }
+                }
 
-                        color as u32
-                    })
-                    .collect::<Vec<_>>();
-
-                surface.set_buffer(&buffer, BUFFER_WIDTH as u16, BUFFER_HEIGHT as u16);
+                surface.present();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -35,7 +35,7 @@ fn main() {
                     .resize(BUFFER_WIDTH as u32, BUFFER_HEIGHT as u32)
                     .unwrap();
 
-                let buffer = surface.buffer_mut().unwrap();
+                let mut buffer = surface.buffer_mut().unwrap();
                 for y in 0..BUFFER_HEIGHT {
                     for x in 0..BUFFER_WIDTH {
                         let red = x as u32 % 255;
@@ -46,8 +46,7 @@ fn main() {
                         buffer[y * BUFFER_WIDTH + x] = color;
                     }
                 }
-
-                surface.present().unwrap();
+                buffer.present().unwrap();
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -31,9 +31,11 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                surface.resize(BUFFER_WIDTH as u32, BUFFER_HEIGHT as u32);
+                surface
+                    .resize(BUFFER_WIDTH as u32, BUFFER_HEIGHT as u32)
+                    .unwrap();
 
-                let buffer = surface.buffer_mut();
+                let buffer = surface.buffer_mut().unwrap();
                 for y in 0..BUFFER_HEIGHT {
                     for x in 0..BUFFER_WIDTH {
                         let red = x as u32 % 255;

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -12,6 +12,7 @@ use cocoa::base::{id, nil};
 use cocoa::quartzcore::{transaction, CALayer, ContentsGravity};
 use foreign_types::ForeignType;
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 struct Buffer(Vec<u32>);
@@ -56,9 +57,9 @@ impl CGImpl {
         })
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
-        self.width = width;
-        self.height = height;
+    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+        self.width = width.get();
+        self.height = height.get();
         Ok(())
     }
 

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -103,12 +103,6 @@ impl CGImpl {
             transaction::commit();
         }
     }
-
-    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        self.resize(width.into(), height.into());
-        self.buffer_mut().copy_from_slice(buffer);
-        self.present();
-    }
 }
 
 impl Drop for CGImpl {

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -76,10 +76,12 @@ pub struct BufferImpl<'a> {
 }
 
 impl<'a> BufferImpl<'a> {
+    #[inline]
     pub fn pixels(&self) -> &[u32] {
         &self.buffer
     }
 
+    #[inline]
     pub fn pixels_mut(&mut self) -> &mut [u32] {
         &mut self.buffer
     }

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -68,7 +68,7 @@ impl CGImpl {
             self.buffer = Some(Vec::new());
         }
         let buffer = self.buffer.as_mut().unwrap();
-        buffer.resize(self.width as usize * self.height as usize * 4, 0);
+        buffer.resize(self.width as usize * self.height as usize, 0);
         buffer.as_mut()
     }
 

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -58,18 +58,19 @@ impl CGImpl {
         })
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) {
+    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
         self.width = width;
         self.height = height;
+        Ok(())
     }
 
-    pub fn buffer_mut(&mut self) -> &mut [u32] {
+    pub fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
         if self.buffer.is_none() {
             self.buffer = Some(Vec::new());
         }
         let buffer = self.buffer.as_mut().unwrap();
         buffer.resize(self.width as usize * self.height as usize, 0);
-        buffer.as_mut()
+        Ok(buffer.as_mut())
     }
 
     pub fn present(&mut self) -> Result<(), SoftBufferError> {

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -72,7 +72,7 @@ impl CGImpl {
         buffer.as_mut()
     }
 
-    pub fn present(&mut self) {
+    pub fn present(&mut self) -> Result<(), SoftBufferError> {
         if let Some(buffer) = self.buffer.take() {
             let data_provider = CGDataProvider::from_buffer(Arc::new(Buffer(buffer)));
             let image = CGImage::new(
@@ -102,6 +102,8 @@ impl CGImpl {
 
             transaction::commit();
         }
+
+        Ok(())
     }
 }
 

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -14,8 +14,20 @@ use foreign_types::ForeignType;
 
 use std::sync::Arc;
 
+struct Buffer(Vec<u32>);
+
+impl AsRef<[u8]> for Buffer {
+    fn as_ref(&self) -> &[u8] {
+        bytemuck::cast_slice(&self.0)
+    }
+}
+
 pub struct CGImpl {
     layer: CALayer,
+    color_space: CGColorSpace,
+    buffer: Option<Vec<u32>>,
+    width: u32,
+    height: u32,
 }
 
 impl CGImpl {
@@ -34,36 +46,61 @@ impl CGImpl {
             view.addSubview_(subview); // retains subview (+1) = 2
             let _: () = msg_send![subview, release]; // releases subview (-1) = 1
         }
-        Ok(Self { layer })
+        let color_space = CGColorSpace::create_device_rgb();
+        Ok(Self {
+            layer,
+            color_space,
+            width: 0,
+            height: 0,
+            buffer: None,
+        })
+    }
+
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.width = width;
+        self.height = height;
+    }
+
+    pub fn buffer_mut(&mut self) -> &mut [u32] {
+        if self.buffer.is_none() {
+            self.buffer = Some(Vec::new());
+        }
+        let buffer = self.buffer.as_mut().unwrap();
+        buffer.resize(self.width as usize * self.height as usize * 4, 0);
+        buffer.as_mut()
+    }
+
+    pub fn present(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            let data_provider = CGDataProvider::from_buffer(Arc::new(Buffer(buffer)));
+            let image = CGImage::new(
+                self.width as usize,
+                self.height as usize,
+                8,
+                32,
+                (self.width * 4) as usize,
+                &self.color_space,
+                kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst,
+                &data_provider,
+                false,
+                kCGRenderingIntentDefault,
+            );
+
+            // The CALayer has a default action associated with a change in the layer contents, causing
+            // a quarter second fade transition to happen every time a new buffer is applied. This can
+            // be mitigated by wrapping the operation in a transaction and disabling all actions.
+            transaction::begin();
+            transaction::set_disable_actions(true);
+
+            unsafe { self.layer.set_contents(image.as_ptr() as id) };
+
+            transaction::commit();
+        }
     }
 
     pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        let color_space = CGColorSpace::create_device_rgb();
-        let data =
-            unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, buffer.len() * 4) }
-                .to_vec();
-        let data_provider = CGDataProvider::from_buffer(Arc::new(data));
-        let image = CGImage::new(
-            width as usize,
-            height as usize,
-            8,
-            32,
-            (width * 4) as usize,
-            &color_space,
-            kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst,
-            &data_provider,
-            false,
-            kCGRenderingIntentDefault,
-        );
-
-        // The CALayer has a default action associated with a change in the layer contents, causing
-        // a quarter second fade transition to happen every time a new buffer is applied. This can
-        // be mitigated by wrapping the operation in a transaction and disabling all actions.
-        transaction::begin();
-        transaction::set_disable_actions(true);
-
-        unsafe { self.layer.set_contents(image.as_ptr() as id) };
-
-        transaction::commit();
+        self.resize(width.into(), height.into());
+        self.buffer_mut().copy_from_slice(buffer);
+        self.present();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use std::error::Error;
+use std::num::NonZeroU32;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -29,7 +30,10 @@ pub enum SoftBufferError {
     IncompleteDisplayHandle,
 
     #[error("Surface size {width}x{height} out of range for backend.")]
-    SizeOutOfRange { width: u32, height: u32 },
+    SizeOutOfRange {
+        width: NonZeroU32,
+        height: NonZeroU32,
+    },
 
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum SoftBufferError {
     #[error("The provided display handle is null.")]
     IncompleteDisplayHandle,
 
+    #[error("Surface size {width}x{height} out of range for backend.")]
+    SizeOutOfRange { width: u32, height: u32 },
+
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[allow(missing_docs)] // TODO
 #[non_exhaustive]
 pub enum SoftBufferError {
     #[error(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod error;
 mod util;
 
 use std::marker::PhantomData;
+use std::num::NonZeroU32;
 use std::ops;
 #[cfg(any(wayland_platform, x11_platform))]
 use std::rc::Rc;
@@ -76,7 +77,7 @@ macro_rules! make_dispatch {
         }
 
         impl SurfaceDispatch {
-            pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
+            pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
@@ -297,7 +298,7 @@ impl Surface {
     /// in the upper-left corner of the window. It is recommended in most production use cases
     /// to have the buffer fill the entire window. Use your windowing library to find the size
     /// of the window.
-    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
+    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         self.surface_impl.resize(width, height)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ impl Surface {
 /// This derefs to a `[u32]`, which depending on the backend may be a mapping into shared memory
 /// accessible to the display server, so presentation doesn't require any (client-side) copying.
 ///
-/// This trust the display server not to mutate the buffer, which could otherwise be unsound.
+/// This trusts the display server not to mutate the buffer, which could otherwise be unsound.
 ///
 /// # Data representation
 ///
@@ -338,6 +338,16 @@ impl Surface {
 /// R: Red channel
 /// G: Green channel
 /// B: Blue channel
+///
+/// # Platform dependent behavior
+/// No-copy presentation is currently supported on:
+/// - Wayland
+/// - X, when XShm is available
+/// - Win32
+/// - Orbital, when buffer size matches window size
+/// Currently [`Buffer::present`] must block copying image data on:
+/// - Web
+/// - macOS
 pub struct Buffer<'a> {
     buffer_impl: BufferDispatch<'a>,
     _marker: PhantomData<*mut ()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ macro_rules! make_dispatch {
         }
 
         impl<'a> BufferDispatch<'a> {
+            #[inline]
             pub fn pixels(&self) -> &[u32] {
                 match self {
                     $(
@@ -111,6 +112,7 @@ macro_rules! make_dispatch {
                 }
             }
 
+            #[inline]
             pub fn pixels_mut(&mut self) -> &mut [u32] {
                 match self {
                     $(
@@ -133,7 +135,6 @@ macro_rules! make_dispatch {
 }
 
 // XXX empty enum with generic bound is invalid?
-// XXX deref
 
 make_dispatch! {
     #[cfg(x11_platform)]
@@ -356,12 +357,14 @@ impl<'a> Buffer<'a> {
 impl<'a> ops::Deref for Buffer<'a> {
     type Target = [u32];
 
+    #[inline]
     fn deref(&self) -> &[u32] {
         self.buffer_impl.pixels()
     }
 }
 
 impl<'a> ops::DerefMut for Buffer<'a> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut [u32] {
         self.buffer_impl.pixels_mut()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! make_dispatch {
         }
 
         impl SurfaceDispatch {
-            pub fn resize(&mut self, width: u32, height: u32) {
+            pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
@@ -82,7 +82,7 @@ macro_rules! make_dispatch {
                 }
             }
 
-            pub fn buffer_mut(&mut self) -> &mut [u32] {
+            pub fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
@@ -262,8 +262,8 @@ impl Surface {
     /// in the upper-left corner of the window. It is recommended in most production use cases
     /// to have the buffer fill the entire window. Use your windowing library to find the size
     /// of the window.
-    pub fn resize(&mut self, width: u32, height: u32) {
-        self.surface_impl.resize(width, height);
+    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
+        self.surface_impl.resize(width, height)
     }
 
     /// Return a mutable slice to the buffer that the next frame should be rendered into. The size
@@ -287,7 +287,7 @@ impl Surface {
     /// R: Red channel
     /// G: Green channel
     /// B: Blue channel
-    pub fn buffer_mut(&mut self) -> &mut [u32] {
+    pub fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
         self.surface_impl.buffer_mut()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ macro_rules! make_dispatch {
                 }
             }
 
-            pub fn present(&mut self) {
+            pub fn present(&mut self) -> Result<(), SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
@@ -306,8 +306,8 @@ impl Surface {
     ///
     /// If the caller wishes to synchronize other surface/window changes, such requests must be sent to the
     /// Wayland compositor before calling this function.
-    pub fn present(&mut self) {
-        self.surface_impl.present();
+    pub fn present(&mut self) -> Result<(), SoftBufferError> {
+        self.surface_impl.present()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,33 @@ macro_rules! make_dispatch {
         }
 
         impl SurfaceDispatch {
+            pub fn resize(&mut self, width: u32, height: u32) {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.resize(width, height),
+                    )*
+                }
+            }
+
+            pub fn buffer_mut(&mut self) -> &mut [u32] {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.buffer_mut(),
+                    )*
+                }
+            }
+
+            pub fn present(&mut self) {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.present(),
+                    )*
+                }
+            }
+
             unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
                 match self {
                     $(
@@ -233,6 +260,18 @@ impl Surface {
         Ok(Self {
             surface_impl: Box::new(imple),
         })
+    }
+
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.surface_impl.resize(width, height);
+    }
+
+    pub fn buffer_mut(&mut self) -> &mut [u32] {
+        self.surface_impl.buffer_mut()
+    }
+
+    pub fn present(&mut self) {
+        self.surface_impl.present();
     }
 
     /// Shows the given buffer with the given width and height on the window corresponding to this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod x11;
 
 mod error;
 
+use std::marker::PhantomData;
 #[cfg(any(wayland_platform, x11_platform))]
 use std::sync::Arc;
 
@@ -35,6 +36,7 @@ use raw_window_handle::{
 pub struct Context {
     /// The inner static dispatch object.
     context_impl: ContextDispatch,
+    _marker: PhantomData<*mut ()>,
 }
 
 /// A macro for creating the enum used to statically dispatch to the platform-specific implementation.
@@ -167,6 +169,7 @@ impl Context {
 
         Ok(Self {
             context_impl: imple,
+            _marker: PhantomData,
         })
     }
 }
@@ -174,6 +177,7 @@ impl Context {
 pub struct Surface {
     /// This is boxed so that `Surface` is the same size on every platform.
     surface_impl: Box<SurfaceDispatch>,
+    _marker: PhantomData<*mut ()>,
 }
 
 impl Surface {
@@ -250,6 +254,7 @@ impl Surface {
 
         Ok(Self {
             surface_impl: Box::new(imple),
+            _marker: PhantomData,
         })
     }
 

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -156,6 +156,7 @@ pub struct BufferImpl<'a> {
 }
 
 impl<'a> BufferImpl<'a> {
+    #[inline]
     pub fn pixels(&self) -> &[u32] {
         match &self.pixels {
             Pixels::Mapping(mapping) => unsafe { mapping.data() },
@@ -163,6 +164,7 @@ impl<'a> BufferImpl<'a> {
         }
     }
 
+    #[inline]
     pub fn pixels_mut(&mut self) -> &mut [u32] {
         match &mut self.pixels {
             Pixels::Mapping(mapping) => unsafe { mapping.data_mut() },

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -69,10 +69,10 @@ impl OrbitalImpl {
     }
 
     pub fn present(&mut self) {
-        unsafe { self.set_buffer(&self.buffer, self.width as u16, self.height as u16) };
+        self.set_buffer(&self.buffer, self.width, self.height);
     }
 
-    pub unsafe fn set_buffer(&self, buffer: &[u32], width_u16: u16, height_u16: u16) {
+    fn set_buffer(&self, buffer: &[u32], width_u32: u32, height_u32: u32) {
         let window_fd = self.handle.window as usize;
 
         // Read the current width and size
@@ -107,8 +107,8 @@ impl OrbitalImpl {
             };
 
             // Copy each line, cropping to fit
-            let width = width_u16 as usize;
-            let height = height_u16 as usize;
+            let width = width_u32 as usize;
+            let height = height_u32 as usize;
             let min_width = cmp::min(width, window_width);
             let min_height = cmp::min(height, window_height);
             for y in 0..min_height {

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -68,8 +68,9 @@ impl OrbitalImpl {
         &mut self.buffer
     }
 
-    pub fn present(&mut self) {
+    pub fn present(&mut self) -> Result<(), SoftBufferError> {
         self.set_buffer(&self.buffer, self.width, self.height);
+        Ok(())
     }
 
     fn set_buffer(&self, buffer: &[u32], width_u32: u32, height_u32: u32) {

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -42,14 +42,37 @@ impl Drop for OrbitalMap {
 
 pub struct OrbitalImpl {
     handle: OrbitalWindowHandle,
+    width: u32,
+    height: u32,
+    buffer: Vec<u32>,
 }
 
 impl OrbitalImpl {
     pub fn new(handle: OrbitalWindowHandle) -> Result<Self, SoftBufferError> {
-        Ok(Self { handle })
+        Ok(Self {
+            handle,
+            width: 0,
+            height: 0,
+            buffer: Vec::new(),
+        })
     }
 
-    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width_u16: u16, height_u16: u16) {
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.width = width;
+        self.height = height;
+    }
+
+    pub fn buffer_mut(&mut self) -> &mut [u32] {
+        self.buffer
+            .resize(self.width as usize * self.height as usize, 0);
+        &mut self.buffer
+    }
+
+    pub fn present(&mut self) {
+        unsafe { self.set_buffer(&self.buffer, self.width as u16, self.height as u16) };
+    }
+
+    pub unsafe fn set_buffer(&self, buffer: &[u32], width_u16: u16, height_u16: u16) {
         let window_fd = self.handle.window as usize;
 
         // Read the current width and size

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -1,5 +1,5 @@
 use raw_window_handle::OrbitalWindowHandle;
-use std::{cmp, slice, str};
+use std::{cmp, num::NonZeroU32, slice, str};
 
 use crate::SoftBufferError;
 
@@ -68,9 +68,9 @@ impl OrbitalImpl {
         })
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
-        self.width = width;
-        self.height = height;
+    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+        self.width = width.get();
+        self.height = height.get();
         Ok(())
     }
 

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -57,15 +57,16 @@ impl OrbitalImpl {
         })
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) {
+    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
         self.width = width;
         self.height = height;
+        Ok(())
     }
 
-    pub fn buffer_mut(&mut self) -> &mut [u32] {
+    pub fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
         self.buffer
             .resize(self.width as usize * self.height as usize, 0);
-        &mut self.buffer
+        Ok(&mut self.buffer)
     }
 
     pub fn present(&mut self) -> Result<(), SoftBufferError> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,63 @@
+// Not needed on all platforms
+#![allow(dead_code)]
+
+use crate::SoftBufferError;
+
+/// Takes a mutable reference to a container and a function deriving a
+/// reference into it, and stores both, making it possible to get back the
+/// reference to the container once the other reference is no longer needed.
+///
+/// This should be consistent with stacked borrow rules, and miri seems to
+/// accept it at least in simple cases.
+pub struct BorrowStack<'a, T: 'static + ?Sized, U: 'static + ?Sized> {
+    container: *mut T,
+    member: *mut U,
+    _phantom: std::marker::PhantomData<&'a mut T>,
+}
+
+impl<'a, T: 'static + ?Sized, U: 'static + ?Sized> BorrowStack<'a, T, U> {
+    pub fn new<F>(container: &'a mut T, f: F) -> Result<Self, SoftBufferError>
+    where
+        F: for<'b> FnOnce(&'b mut T) -> Result<&'b mut U, SoftBufferError>,
+    {
+        let container = container as *mut T;
+        let member = f(unsafe { &mut *container })? as *mut U;
+        Ok(Self {
+            container,
+            member,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+
+    pub fn member(&self) -> &U {
+        unsafe { &*self.member }
+    }
+
+    pub fn member_mut(&mut self) -> &mut U {
+        unsafe { &mut *self.member }
+    }
+
+    pub fn into_container(self) -> &'a mut T {
+        // SAFETY: Since we consume self and no longer reference member, this
+        // mutable reference is unique.
+        unsafe { &mut *self.container }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_borrowstack_slice_int() {
+        fn f(mut stack: BorrowStack<[u32], u32>) {
+            assert_eq!(*stack.member(), 3);
+            *stack.member_mut() = 42;
+            assert_eq!(stack.into_container(), &[1, 2, 42, 4, 5]);
+        }
+
+        let mut v = vec![1, 2, 3, 4, 5];
+        f(BorrowStack::new(v.as_mut(), |v: &mut [u32]| Ok(&mut v[2])).unwrap());
+        assert_eq!(&v, &[1, 2, 42, 4, 5]);
+    }
+}

--- a/src/wayland/buffer.rs
+++ b/src/wayland/buffer.rs
@@ -1,7 +1,9 @@
+use memmap2::MmapMut;
 use std::{
     ffi::CStr,
     fs::File,
-    os::unix::prelude::{AsRawFd, FileExt, FromRawFd},
+    os::unix::prelude::{AsRawFd, FromRawFd},
+    slice,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -69,9 +71,19 @@ fn create_memfile() -> File {
     panic!("Failed to generate non-existant shm name")
 }
 
+// Round size to use for pool for given dimentions, rounding up to power of 2
+fn get_pool_size(width: i32, height: i32) -> i32 {
+    ((width * height * 4) as u32).next_power_of_two() as i32
+}
+
+unsafe fn map_file(file: &File) -> MmapMut {
+    unsafe { MmapMut::map_mut(file.as_raw_fd()).expect("Failed to map shared memory") }
+}
+
 pub(super) struct WaylandBuffer {
     qh: QueueHandle<State>,
     tempfile: File,
+    map: MmapMut,
     pool: wl_shm_pool::WlShmPool,
     pool_size: i32,
     buffer: wl_buffer::WlBuffer,
@@ -82,8 +94,15 @@ pub(super) struct WaylandBuffer {
 
 impl WaylandBuffer {
     pub fn new(shm: &wl_shm::WlShm, width: i32, height: i32, qh: &QueueHandle<State>) -> Self {
+        // Calculate size to use for shm pool
+        let pool_size = get_pool_size(width, height);
+
+        // Create an `mmap` shared memory
         let tempfile = create_memfile();
-        let pool_size = width * height * 4;
+        let _ = tempfile.set_len(pool_size as u64);
+        let map = unsafe { map_file(&tempfile) };
+
+        // Create wayland shm pool and buffer
         let pool = shm.create_pool(tempfile.as_raw_fd(), pool_size, qh, ());
         let released = Arc::new(AtomicBool::new(true));
         let buffer = pool.create_buffer(
@@ -95,8 +114,10 @@ impl WaylandBuffer {
             qh,
             released.clone(),
         );
+
         Self {
             qh: qh.clone(),
+            map,
             tempfile,
             pool,
             pool_size,
@@ -119,6 +140,7 @@ impl WaylandBuffer {
                 let _ = self.tempfile.set_len(size as u64);
                 self.pool.resize(size);
                 self.pool_size = size;
+                self.map = unsafe { map_file(&self.tempfile) };
             }
 
             // Create buffer with correct size
@@ -131,15 +153,10 @@ impl WaylandBuffer {
                 &self.qh,
                 self.released.clone(),
             );
-        }
-    }
 
-    pub fn write(&self, buffer: &[u32]) {
-        let buffer =
-            unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, buffer.len() * 4) };
-        self.tempfile
-            .write_all_at(buffer, 0)
-            .expect("Failed to write buffer to temporary file.");
+            self.width = width;
+            self.height = height;
+        }
     }
 
     pub fn attach(&self, surface: &wl_surface::WlSurface) {
@@ -149,6 +166,14 @@ impl WaylandBuffer {
 
     pub fn released(&self) -> bool {
         self.released.load(Ordering::SeqCst)
+    }
+
+    fn len(&self) -> usize {
+        self.width as usize * self.height as usize
+    }
+
+    pub unsafe fn mapped_mut(&mut self) -> &mut [u32] {
+        unsafe { slice::from_raw_parts_mut(self.map.as_mut_ptr() as *mut u32, self.len()) }
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -144,12 +144,6 @@ impl WaylandImpl {
 
         let _ = self.display.event_queue.lock().unwrap().flush();
     }
-
-    pub unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        self.resize(width.into(), height.into());
-        self.buffer_mut().copy_from_slice(buffer);
-        self.present();
-    }
 }
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -137,10 +137,12 @@ impl WaylandImpl {
 pub struct BufferImpl<'a>(util::BorrowStack<'a, WaylandImpl, [u32]>);
 
 impl<'a> BufferImpl<'a> {
+    #[inline]
     pub fn pixels(&self) -> &[u32] {
         self.0.member()
     }
 
+    #[inline]
     pub fn pixels_mut(&mut self) -> &mut [u32] {
         self.0.member_mut()
     }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -111,7 +111,7 @@ impl WaylandImpl {
         unsafe { self.buffers.as_mut().unwrap().1.mapped_mut() }
     }
 
-    pub fn present(&mut self) {
+    pub fn present(&mut self) -> Result<(), SoftBufferError> {
         let _ = self
             .display
             .event_queue
@@ -142,6 +142,8 @@ impl WaylandImpl {
         }
 
         let _ = self.display.event_queue.borrow_mut().flush();
+
+        Ok(())
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::unwrap, SoftBufferError};
+use crate::{error::unwrap, util, SoftBufferError};
 use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle};
 use std::{cell::RefCell, num::NonZeroI32, rc::Rc};
 use wayland_client::{
@@ -89,7 +89,7 @@ impl WaylandImpl {
         Ok(())
     }
 
-    pub fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
+    pub fn buffer_mut(&mut self) -> Result<BufferImpl, SoftBufferError> {
         let (width, height) = self
             .size
             .expect("Must set size of surface before calling `buffer_mut()`");
@@ -128,45 +128,60 @@ impl WaylandImpl {
             ));
         };
 
-        Ok(unsafe { self.buffers.as_mut().unwrap().1.mapped_mut() })
+        Ok(BufferImpl(util::BorrowStack::new(self, |buffer| {
+            Ok(unsafe { buffer.buffers.as_mut().unwrap().1.mapped_mut() })
+        })?))
+    }
+}
+
+pub struct BufferImpl<'a>(util::BorrowStack<'a, WaylandImpl, [u32]>);
+
+impl<'a> BufferImpl<'a> {
+    pub fn pixels(&self) -> &[u32] {
+        self.0.member()
     }
 
-    pub fn present(&mut self) -> Result<(), SoftBufferError> {
-        let (width, height) = self
+    pub fn pixels_mut(&mut self) -> &mut [u32] {
+        self.0.member_mut()
+    }
+
+    pub fn present(self) -> Result<(), SoftBufferError> {
+        let imp = self.0.into_container();
+
+        let (width, height) = imp
             .size
             .expect("Must set size of surface before calling `present()`");
 
-        let _ = self
+        let _ = imp
             .display
             .event_queue
             .borrow_mut()
             .dispatch_pending(&mut State);
 
-        if let Some((front, back)) = &mut self.buffers {
+        if let Some((front, back)) = &mut imp.buffers {
             // Swap front and back buffer
             std::mem::swap(front, back);
 
-            front.attach(&self.surface);
+            front.attach(&imp.surface);
 
             // FIXME: Proper damaging mechanism.
             //
             // In order to propagate changes on compositors which track damage, for now damage the entire surface.
-            if self.surface.version() < 4 {
+            if imp.surface.version() < 4 {
                 // FIXME: Accommodate scale factor since wl_surface::damage is in terms of surface coordinates while
                 // wl_surface::damage_buffer is in buffer coordinates.
                 //
                 // i32::MAX is a valid damage box (most compositors interpret the damage box as "the entire surface")
-                self.surface.damage(0, 0, i32::MAX, i32::MAX);
+                imp.surface.damage(0, 0, i32::MAX, i32::MAX);
             } else {
                 // Introduced in version 4, it is an error to use this request in version 3 or lower.
-                self.surface
-                    .damage_buffer(0, 0, width.into(), height.into());
+                imp.surface.damage_buffer(0, 0, width.into(), height.into());
             }
 
-            self.surface.commit();
+            imp.surface.commit();
         }
 
-        let _ = self.display.event_queue.borrow_mut().flush();
+        let _ = imp.display.event_queue.borrow_mut().flush();
 
         Ok(())
     }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -87,12 +87,12 @@ impl WaylandImpl {
         ));
     }
 
-    fn resize(&mut self, width: u32, height: u32) {
+    pub fn resize(&mut self, width: u32, height: u32) {
         self.width = width as i32;
         self.height = height as i32;
     }
 
-    fn buffer_mut(&mut self) -> &mut [u32] {
+    pub fn buffer_mut(&mut self) -> &mut [u32] {
         if let Some((_front, back)) = &mut self.buffers {
             // Block if back buffer not released yet
             if !back.released() {
@@ -111,7 +111,7 @@ impl WaylandImpl {
         unsafe { self.buffers.as_mut().unwrap().1.mapped_mut() }
     }
 
-    fn present(&mut self) {
+    pub fn present(&mut self) {
         let _ = self
             .display
             .event_queue

--- a/src/web.rs
+++ b/src/web.rs
@@ -96,16 +96,17 @@ impl WebImpl {
     }
 
     /// Resize the canvas to the given dimensions.
-    pub(crate) fn resize(&mut self, width: u32, height: u32) {
+    pub(crate) fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
         self.buffer.resize(total_len(width, height), 0);
         self.canvas.set_width(width);
         self.canvas.set_height(height);
         self.width = width;
+        Ok(())
     }
 
     /// Get a pointer to the mutable buffer.
-    pub(crate) fn buffer_mut(&mut self) -> &mut [u32] {
-        &mut self.buffer
+    pub(crate) fn buffer_mut(&mut self) -> Result<&mut [u32], SoftBufferError> {
+        Ok(&mut self.buffer)
     }
 
     /// Push the buffer to the canvas.

--- a/src/web.rs
+++ b/src/web.rs
@@ -109,7 +109,7 @@ impl WebImpl {
     }
 
     /// Push the buffer to the canvas.
-    pub(crate) fn present(&mut self) {
+    pub(crate) fn present(&mut self) -> Result<(), SoftBufferError> {
         // Create a bitmap from the buffer.
         let bitmap: Vec<_> = self
             .buffer
@@ -124,6 +124,8 @@ impl WebImpl {
 
         // This can only throw an error if `data` is detached, which is impossible.
         self.ctx.put_image_data(&image_data, 0.0, 0.0).unwrap();
+
+        Ok(())
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -11,6 +11,7 @@ use web_sys::ImageData;
 
 use crate::SoftBufferError;
 use std::convert::TryInto;
+use std::num::NonZeroU32;
 
 /// Display implementation for the web platform.
 ///
@@ -96,7 +97,14 @@ impl WebImpl {
     }
 
     /// Resize the canvas to the given dimensions.
-    pub(crate) fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
+    pub(crate) fn resize(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> Result<(), SoftBufferError> {
+        let width = width.get();
+        let height = height.get();
+
         self.buffer.resize(total_len(width, height), 0);
         self.canvas.set_width(width);
         self.canvas.set_height(height);

--- a/src/web.rs
+++ b/src/web.rs
@@ -118,18 +118,12 @@ impl WebImpl {
             .flat_map(|pixel| [(pixel >> 16) as u8, (pixel >> 8) as u8, pixel as u8, 255])
             .collect();
 
-        // This should only throw an error if the buffer we pass's size is incorrect, which is checked in the outer `set_buffer` call.
+        // This should only throw an error if the buffer we pass's size is incorrect.
         let image_data =
             ImageData::new_with_u8_clamped_array(Clamped(&bitmap), self.width).unwrap();
 
         // This can only throw an error if `data` is detached, which is impossible.
         self.ctx.put_image_data(&image_data, 0.0, 0.0).unwrap();
-    }
-
-    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        self.resize(width.into(), height.into());
-        self.buffer.copy_from_slice(buffer);
-        self.present();
     }
 }
 

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -107,7 +107,7 @@ impl Buffer {
         unsafe {
             slice::from_raw_parts_mut(
                 self.pixels.as_ptr(),
-                self.width as usize * self.height as usize * 4,
+                self.width as usize * self.height as usize,
             )
         }
     }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -7,7 +7,7 @@ use raw_window_handle::Win32WindowHandle;
 
 use std::io;
 use std::mem;
-use std::num::NonZeroI32;
+use std::num::{NonZeroI32, NonZeroU32};
 use std::ptr::{self, NonNull};
 use std::slice;
 
@@ -47,8 +47,8 @@ impl Buffer {
         let bitmap_info = BitmapInfo {
             bmi_header: Gdi::BITMAPINFOHEADER {
                 biSize: mem::size_of::<Gdi::BITMAPINFOHEADER>() as u32,
-                biWidth: width.into(),
-                biHeight: -i32::from(height),
+                biWidth: width.get(),
+                biHeight: -height.get(),
                 biPlanes: 1,
                 biBitCount: 32,
                 biCompression: Gdi::BI_BITFIELDS,
@@ -164,10 +164,10 @@ impl Win32Impl {
         })
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), SoftBufferError> {
+    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         let (width, height) = (|| {
-            let width = NonZeroI32::new(i32::try_from(width).ok()?)?;
-            let height = NonZeroI32::new(i32::try_from(height).ok()?)?;
+            let width = NonZeroI32::new(i32::try_from(width.get()).ok()?)?;
+            let height = NonZeroI32::new(i32::try_from(height.get()).ok()?)?;
             Some((width, height))
         })()
         .ok_or(SoftBufferError::SizeOutOfRange { width, height })?;
@@ -215,8 +215,8 @@ impl<'a> BufferImpl<'a> {
                 imp.dc,
                 0,
                 0,
-                buffer.width.into(),
-                buffer.height.into(),
+                buffer.width.get(),
+                buffer.height.get(),
                 buffer.dc,
                 0,
                 0,

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -197,10 +197,12 @@ impl Win32Impl {
 pub struct BufferImpl<'a>(util::BorrowStack<'a, Win32Impl, [u32]>);
 
 impl<'a> BufferImpl<'a> {
+    #[inline]
     pub fn pixels(&self) -> &[u32] {
         self.0.member()
     }
 
+    #[inline]
     pub fn pixels_mut(&mut self) -> &mut [u32] {
         self.0.member_mut()
     }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -181,7 +181,7 @@ impl Win32Impl {
         self.buffer.as_mut().map_or(&mut [], Buffer::pixels_mut)
     }
 
-    pub fn present(&mut self) {
+    pub fn present(&mut self) -> Result<(), SoftBufferError> {
         if let Some(buffer) = &self.buffer {
             unsafe {
                 Gdi::BitBlt(
@@ -200,5 +200,7 @@ impl Win32Impl {
                 Gdi::ValidateRect(self.window, ptr::null_mut());
             }
         }
+
+        Ok(())
     }
 }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -7,13 +7,107 @@ use raw_window_handle::Win32WindowHandle;
 
 use std::io;
 use std::mem;
-use std::os::raw::c_int;
+use std::ptr;
+use std::slice;
 
 use windows_sys::Win32::Foundation::HWND;
-use windows_sys::Win32::Graphics::Gdi::{
-    GetDC, StretchDIBits, ValidateRect, BITMAPINFOHEADER, BI_BITFIELDS, DIB_RGB_COLORS, HDC,
-    RGBQUAD, SRCCOPY,
+use windows_sys::Win32::Graphics::Gdi;
+
+const ZERO_QUAD: Gdi::RGBQUAD = Gdi::RGBQUAD {
+    rgbBlue: 0,
+    rgbGreen: 0,
+    rgbRed: 0,
+    rgbReserved: 0,
 };
+
+struct Buffer {
+    dc: Gdi::HDC,
+    bitmap: Gdi::HBITMAP,
+    pixels: *mut u32,
+    width: i32,
+    height: i32,
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        unsafe {
+            Gdi::DeleteDC(self.dc);
+            Gdi::DeleteObject(self.bitmap);
+        }
+    }
+}
+
+impl Buffer {
+    fn new(window_dc: Gdi::HDC, width: i32, height: i32) -> Self {
+        let dc = unsafe { Gdi::CreateCompatibleDC(window_dc) };
+        assert!(dc != 0);
+
+        // Create a new bitmap info struct.
+        let bitmap_info = BitmapInfo {
+            bmi_header: Gdi::BITMAPINFOHEADER {
+                biSize: mem::size_of::<Gdi::BITMAPINFOHEADER>() as u32,
+                biWidth: width,
+                biHeight: -height,
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: Gdi::BI_BITFIELDS,
+                biSizeImage: 0,
+                biXPelsPerMeter: 0,
+                biYPelsPerMeter: 0,
+                biClrUsed: 0,
+                biClrImportant: 0,
+            },
+            bmi_colors: [
+                Gdi::RGBQUAD {
+                    rgbRed: 0xff,
+                    ..ZERO_QUAD
+                },
+                Gdi::RGBQUAD {
+                    rgbGreen: 0xff,
+                    ..ZERO_QUAD
+                },
+                Gdi::RGBQUAD {
+                    rgbBlue: 0xff,
+                    ..ZERO_QUAD
+                },
+            ],
+        };
+
+        // XXX alignment?
+        // XXX better to use CreateFileMapping, and pass hSection?
+        // XXX test return value?
+        let mut pixels: *mut u32 = ptr::null_mut();
+        let bitmap = unsafe {
+            Gdi::CreateDIBSection(
+                dc,
+                &bitmap_info as *const BitmapInfo as *const _,
+                Gdi::DIB_RGB_COLORS,
+                &mut pixels as *mut *mut u32 as _,
+                0,
+                0,
+            )
+        };
+        assert!(bitmap != 0);
+
+        unsafe {
+            Gdi::SelectObject(dc, bitmap);
+        }
+
+        Self {
+            dc,
+            bitmap,
+            width,
+            height,
+            pixels,
+        }
+    }
+
+    fn pixels_mut(&mut self) -> &mut [u32] {
+        unsafe {
+            slice::from_raw_parts_mut(self.pixels, self.width as usize * self.height as usize * 4)
+        }
+    }
+}
 
 /// The handle to a window for software buffering.
 pub struct Win32Impl {
@@ -21,14 +115,16 @@ pub struct Win32Impl {
     window: HWND,
 
     /// The device context for the window.
-    dc: HDC,
+    dc: Gdi::HDC,
+
+    buffer: Option<Buffer>,
 }
 
 /// The Win32-compatible bitmap information.
 #[repr(C)]
 struct BitmapInfo {
-    pub bmi_header: BITMAPINFOHEADER,
-    pub bmi_colors: [RGBQUAD; 3],
+    bmi_header: Gdi::BITMAPINFOHEADER,
+    bmi_colors: [Gdi::RGBQUAD; 3],
 }
 
 impl Win32Impl {
@@ -46,7 +142,7 @@ impl Win32Impl {
         // Get the handle to the device context.
         // SAFETY: We have confirmed that the window handle is valid.
         let hwnd = handle.hwnd as HWND;
-        let dc = unsafe { GetDC(hwnd) };
+        let dc = unsafe { Gdi::GetDC(hwnd) };
 
         // GetDC returns null if there is a platform error.
         if dc == 0 {
@@ -56,72 +152,55 @@ impl Win32Impl {
             ));
         }
 
-        Ok(Self { dc, window: hwnd })
+        Ok(Self {
+            dc,
+            window: hwnd,
+            buffer: None,
+        })
     }
 
-    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        // Create a new bitmap info struct.
-        let bmi_header = BITMAPINFOHEADER {
-            biSize: mem::size_of::<BITMAPINFOHEADER>() as u32,
-            biWidth: width as i32,
-            biHeight: -(height as i32),
-            biPlanes: 1,
-            biBitCount: 32,
-            biCompression: BI_BITFIELDS,
-            biSizeImage: 0,
-            biXPelsPerMeter: 0,
-            biYPelsPerMeter: 0,
-            biClrUsed: 0,
-            biClrImportant: 0,
-        };
-        let zero_quad = RGBQUAD {
-            rgbBlue: 0,
-            rgbGreen: 0,
-            rgbRed: 0,
-            rgbReserved: 0,
-        };
-        let bmi_colors = [
-            RGBQUAD {
-                rgbRed: 0xff,
-                ..zero_quad
-            },
-            RGBQUAD {
-                rgbGreen: 0xff,
-                ..zero_quad
-            },
-            RGBQUAD {
-                rgbBlue: 0xff,
-                ..zero_quad
-            },
-        ];
-        let bitmap_info = BitmapInfo {
-            bmi_header,
-            bmi_colors,
-        };
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if let Some(buffer) = self.buffer.as_ref() {
+            if buffer.width == width as i32 && buffer.height == height as i32 {
+                return;
+            }
+        }
 
-        // Stretch the bitmap onto the window.
-        // SAFETY:
-        //  - The bitmap information is valid.
-        //  - The buffer is a valid pointer to image data.
-        unsafe {
-            StretchDIBits(
-                self.dc,
-                0,
-                0,
-                width as c_int,
-                height as c_int,
-                0,
-                0,
-                width as c_int,
-                height as c_int,
-                buffer.as_ptr().cast(),
-                &bitmap_info as *const BitmapInfo as *const _,
-                DIB_RGB_COLORS,
-                SRCCOPY,
-            )
-        };
+        self.buffer = if width != 0 && height != 0 {
+            Some(Buffer::new(self.dc, width as i32, height as i32))
+        } else {
+            None
+        }
+    }
 
-        // Validate the window.
-        unsafe { ValidateRect(self.window, std::ptr::null_mut()) };
+    pub fn buffer_mut(&mut self) -> &mut [u32] {
+        self.buffer.as_mut().map_or(&mut [], Buffer::pixels_mut)
+    }
+
+    pub fn present(&mut self) {
+        if let Some(buffer) = &self.buffer {
+            unsafe {
+                Gdi::BitBlt(
+                    self.dc,
+                    0,
+                    0,
+                    buffer.width,
+                    buffer.height,
+                    buffer.dc,
+                    0,
+                    0,
+                    Gdi::SRCCOPY,
+                );
+
+                // Validate the window.
+                Gdi::ValidateRect(self.window, ptr::null_mut());
+            }
+        }
+    }
+
+    pub unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
+        self.resize(width.into(), height.into());
+        self.buffer_mut().copy_from_slice(buffer);
+        self.present();
     }
 }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -201,10 +201,4 @@ impl Win32Impl {
             }
         }
     }
-
-    pub unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        self.resize(width.into(), height.into());
-        self.buffer_mut().copy_from_slice(buffer);
-        self.present();
-    }
 }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -231,7 +231,12 @@ impl X11Impl {
 
     /// Resize the internal buffer to the given width and height.
     pub(crate) fn resize(&mut self, width: u32, height: u32) {
-        log::trace!("resize: window={:X}, size={}x{}", self.window, width, height);
+        log::trace!(
+            "resize: window={:X}, size={}x{}",
+            self.window,
+            width,
+            height
+        );
 
         // Width and height should fit in u16.
         let width: u16 = width.try_into().expect("Width too large");
@@ -392,7 +397,6 @@ impl ShmBuffer {
             let new_seg = ShmSegment::new(size)?;
             self.associate(conn, new_seg)?;
         }
-
 
         Ok(())
     }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -342,12 +342,6 @@ impl X11Impl {
             log::error!("Failed to draw image to window: {}", e);
         }
     }
-
-    pub(crate) unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
-        self.resize(width.into(), height.into());
-        self.buffer_mut().copy_from_slice(buffer);
-        self.present();
-    }
 }
 
 impl Buffer {

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -274,7 +274,7 @@ impl X11Impl {
     }
 
     /// Push the buffer to the window.
-    pub(crate) fn present(&mut self) {
+    pub(crate) fn present(&mut self) -> Result<(), SoftBufferError> {
         log::trace!("present: window={:X}", self.window);
 
         let result = match self.buffer {
@@ -338,9 +338,12 @@ impl X11Impl {
             }
         };
 
-        if let Err(e) = result {
-            log::error!("Failed to draw image to window: {}", e);
-        }
+        result.map_err(|err| {
+            SoftBufferError::PlatformError(
+                Some("Failed to draw image to window".to_string()),
+                Some(Box::new(err)),
+            )
+        })
     }
 }
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -250,12 +250,7 @@ impl X11Impl {
         if width != self.width || height != self.height {
             self.buffer
                 .resize(&self.display.connection, width, height)
-                .map_err(|err| {
-                    SoftBufferError::PlatformError(
-                        Some("Failed to resize X11 buffer".to_string()),
-                        Some(Box::new(err)),
-                    )
-                })?;
+                .swbuf_err("Failed to resize X11 buffer")?;
 
             // We successfully resized the buffer.
             self.width = width;
@@ -273,12 +268,7 @@ impl X11Impl {
             let buffer = surface
                 .buffer
                 .buffer_mut(&surface.display.connection)
-                .map_err(|err| {
-                    SoftBufferError::PlatformError(
-                        Some("Failed to get mutable X11 buffer".to_string()),
-                        Some(Box::new(err)),
-                    )
-                })?;
+                .swbuf_err("Failed to get mutable X11 buffer")?;
 
             // Crop it down to the window size.
             Ok(&mut buffer[..total_len(surface.width, surface.height) / 4])
@@ -364,12 +354,7 @@ impl<'a> BufferImpl<'a> {
             }
         };
 
-        result.map_err(|err| {
-            SoftBufferError::PlatformError(
-                Some("Failed to draw image to window".to_string()),
-                Some(Box::new(err)),
-            )
-        })
+        result.swbuf_err("Failed to draw image to window")
     }
 }
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -9,7 +9,7 @@ use crate::SoftBufferError;
 use nix::libc::{shmat, shmctl, shmdt, shmget, IPC_PRIVATE, IPC_RMID};
 use raw_window_handle::{XcbDisplayHandle, XcbWindowHandle, XlibDisplayHandle, XlibWindowHandle};
 use std::ptr::{null_mut, NonNull};
-use std::{fmt, io, mem, sync::Arc};
+use std::{fmt, io, mem, rc::Rc};
 
 use x11_dl::xlib::Display;
 use x11_dl::xlib_xcb::Xlib_xcb;
@@ -94,7 +94,7 @@ impl X11DisplayImpl {
 /// The handle to an X11 drawing context.
 pub struct X11Impl {
     /// X display this window belongs to.
-    display: Arc<X11DisplayImpl>,
+    display: Rc<X11DisplayImpl>,
 
     /// The window to draw to.
     window: xproto::Window,
@@ -151,7 +151,7 @@ impl X11Impl {
     /// The `XlibWindowHandle` and `XlibDisplayHandle` must be valid.
     pub unsafe fn from_xlib(
         window_handle: XlibWindowHandle,
-        display: Arc<X11DisplayImpl>,
+        display: Rc<X11DisplayImpl>,
     ) -> Result<Self, SoftBufferError> {
         let mut xcb_window_handle = XcbWindowHandle::empty();
         xcb_window_handle.window = window_handle.window as _;
@@ -168,7 +168,7 @@ impl X11Impl {
     /// The `XcbWindowHandle` and `XcbDisplayHandle` must be valid.
     pub(crate) unsafe fn from_xcb(
         window_handle: XcbWindowHandle,
-        display: Arc<X11DisplayImpl>,
+        display: Rc<X11DisplayImpl>,
     ) -> Result<Self, SoftBufferError> {
         log::trace!("new: window_handle={:X}", window_handle.window,);
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -279,10 +279,12 @@ impl X11Impl {
 pub struct BufferImpl<'a>(util::BorrowStack<'a, X11Impl, [u32]>);
 
 impl<'a> BufferImpl<'a> {
+    #[inline]
     pub fn pixels(&self) -> &[u32] {
         self.0.member()
     }
 
+    #[inline]
     pub fn pixels_mut(&mut self) -> &mut [u32] {
         self.0.member_mut()
     }


### PR DESCRIPTION
WIP implementation of https://github.com/rust-windowing/softbuffer/issues/40.

Currently this only has Wayland. It can be run with `cargo run --no-default-features --features wayland --example winit`.

We should do some testing to see what impact it actually has.