### PR TITLE
m: Cache document in web frontend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ make_dispatch! {
     #[cfg(target_os = "macos")]
     CG((), cg::CGImpl),
     #[cfg(target_arch = "wasm32")]
-    Web((), web::WebImpl),
+    Web(web::WebDisplayImpl, web::WebImpl),
     #[cfg(target_os = "redox")]
     Orbital((), orbital::OrbitalImpl),
 }
@@ -134,7 +134,7 @@ impl Context {
             #[cfg(target_os = "macos")]
             RawDisplayHandle::AppKit(_) => ContextDispatch::CG(()),
             #[cfg(target_arch = "wasm32")]
-            RawDisplayHandle::Web(_) => ContextDispatch::Web(()),
+            RawDisplayHandle::Web(_) => ContextDispatch::Web(web::WebDisplayImpl::new()?),
             #[cfg(target_os = "redox")]
             RawDisplayHandle::Orbital(_) => ContextDispatch::Orbital(()),
             unimplemented_display_handle => {
@@ -212,8 +212,8 @@ impl Surface {
                 SurfaceDispatch::CG(unsafe { cg::CGImpl::new(appkit_handle)? })
             }
             #[cfg(target_arch = "wasm32")]
-            (ContextDispatch::Web(()), RawWindowHandle::Web(web_handle)) => {
-                SurfaceDispatch::Web(web::WebImpl::new(web_handle)?)
+            (ContextDispatch::Web(context), RawWindowHandle::Web(web_handle)) => {
+                SurfaceDispatch::Web(web::WebImpl::new(context, web_handle)?)
             }
             #[cfg(target_os = "redox")]
             (ContextDispatch::Orbital(()), RawWindowHandle::Orbital(orbital_handle)) => {


### PR DESCRIPTION
This PR caches the `window().document()` call in the `Display` type for the web backend of this crate. This is just an optimization to prevent having to query the document multiple times. I'm not too familiar with web technology, so if this is invalid (if, e.g. `document` can change during operation), please let me know.