### PR TITLE
fix: update width and height when resizing buffer

### DIFF
--- a/src/wayland/buffer.rs
+++ b/src/wayland/buffer.rs
@@ -131,6 +131,8 @@ impl WaylandBuffer {
                 &self.qh,
                 self.released.clone(),
             );
+            self.width = width;
+            self.height = height;
         }
     }
 


### PR DESCRIPTION
This caused some issues for me when resizing a surface, which seem to be fixed by updating the width and height during a resize.