### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x11rb = { version = "0.11.0", features = ["allow-unsafe-code", "dl-libxcb", "shm
 fastrand = { version = "1.8.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45.0"
 features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -60,7 +60,7 @@ cfg_aliases = "0.1.1"
 
 [dev-dependencies]
 instant = "0.1.12"
-winit = "0.27.2"
+winit = "0.28.1"
 
 [dev-dependencies.image]
 version = "0.23.14"

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -54,12 +54,6 @@ fn main() {
             } if window_id == window.id() => {
                 *control_flow = ControlFlow::Exit;
             }
-            Event::WindowEvent {
-                event: WindowEvent::Resized(_),
-                window_id,
-            } if window_id == window.id() => {
-                window.request_redraw();
-            }
             _ => {}
         }
     });


### PR DESCRIPTION
Using the latest `winit` version in examples fixes resizing behavior on Wayland, so the workaround for that in the `winit` example is also removed here.