### PR TITLE
Add `run-wasm` workspace member, as used in `winit`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+run-wasm = ["run", "--release", "--package", "run-wasm", "--"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,8 @@ features = ["jpeg"]
 # Turn rayon back on everywhere else; creating the separate entry resets the features to default.
 image = "0.23.14"
 rayon = "1.5.1"
+
+[workspace]
+members = [
+    "run-wasm",
+]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ For now, the priority for new platforms is:
  - Xcb ❌
  - Xlib ✅
 
+WebAssembly
+-----------
+
+To run an example with the web backend: `cargo run-wasm --example winit`
+
 Example
 ==
 ```rust,no_run

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "run-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cargo-run-wasm = "0.3.0"

--- a/run-wasm/src/main.rs
+++ b/run-wasm/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
+}


### PR DESCRIPTION
This makes it easy to run examples with the web backend, in the same way that winit examples are run.