### PR TITLE
added `from_canvas` and `from_offscreen_canvas` methods to `Surface`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ wasm-bindgen = "0.2.78"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.55"
-features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "Window"]
+features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "OffscreenCanvas", "Window"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,7 @@ impl Surface {
         })
     }
 
+    /// Creates a new instance of this struct, using the provided [`HtmlCanvasElement`](web_sys::HtmlCanvasElement).
     #[cfg(target_arch = "wasm32")]
     pub fn from_canvas(canvas: web_sys::HtmlCanvasElement) -> Result<Self, SoftBufferError> {
         let imple = SurfaceDispatch::Web(web::WebImpl::from_canvas(canvas)?);
@@ -244,6 +245,7 @@ impl Surface {
         })
     }
 
+    /// Creates a new instance of this struct, using the provided [`HtmlCanvasElement`](web_sys::OffscreenCanvas).
     #[cfg(target_arch = "wasm32")]
     pub fn from_offscreen_canvas(
         offscreen_canvas: web_sys::OffscreenCanvas,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,26 @@ impl Surface {
         })
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_canvas(canvas: web_sys::HtmlCanvasElement) -> Result<Self, SoftBufferError> {
+        let imple = SurfaceDispatch::Web(web::WebImpl::from_canvas(canvas)?);
+
+        Ok(Self {
+            surface_impl: Box::new(imple),
+        })
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_offscreen_canvas(
+        offscreen_canvas: web_sys::OffscreenCanvas,
+    ) -> Result<Self, SoftBufferError> {
+        let imple = SurfaceDispatch::Web(web::WebImpl::from_offscreen_canvas(offscreen_canvas)?);
+
+        Ok(Self {
+            surface_impl: Box::new(imple),
+        })
+    }
+
     /// Shows the given buffer with the given width and height on the window corresponding to this
     /// graphics context. Panics if buffer.len() ≠ width*height. If the size of the buffer does
     /// not match the size of the window, the buffer is drawn in the upper-left corner of the window.


### PR DESCRIPTION
Added methods to create `Surface` from a `HtmlCanvasElement` or `OffscreenCanvas` following wgpu's example https://github.com/gfx-rs/wgpu/blob/v0.15.1/wgpu/src/lib.rs#L1570-L1640

My use case required this to render in a web worker.

Edit: See this for a future alternative implementation https://github.com/rust-windowing/raw-window-handle/issues/102