### PR TITLE
Add `from_canvas()` to `Surface` for Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,14 @@ jobs:
         !contains(matrix.platform.target, 'freebsd') &&
         !contains(matrix.platform.target, 'netbsd')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
+
+    - name: Lint with rustdoc
+      shell: bash
+      if: >
+        (matrix.rust_version == 'stable') &&
+        !contains(matrix.platform.options, '--no-default-features') &&
+        !((matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')) &&
+        !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'freebsd') &&
+        !contains(matrix.platform.target, 'netbsd')
+      run: cargo doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ wasm-bindgen = "0.2.78"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.55"
-features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "Window"]
+features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "OffscreenCanvas", "Window"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,10 @@ members = [
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ wasm-bindgen = "0.2.78"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.55"
-features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "OffscreenCanvas", "Window"]
+features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElement", "ImageData", "Window"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,8 @@ rayon = "1.5.1"
 members = [
     "run-wasm",
 ]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ use raw_window_handle::{
     HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
+#[cfg(target_arch = "wasm32")]
+pub use self::web::SurfaceExtWeb;
+
 /// An instance of this struct contains the platform-specific data that must be managed in order to
 /// write to a window on that platform.
 pub struct Context {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(target_os = "macos")]
 #[macro_use]

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,15 +2,20 @@
 
 #![allow(clippy::uninlined_format_args)]
 
+use js_sys::Object;
 use raw_window_handle::WebWindowHandle;
+use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
 use web_sys::CanvasRenderingContext2d;
 use web_sys::HtmlCanvasElement;
 use web_sys::ImageData;
+use web_sys::OffscreenCanvas;
 
 use crate::error::SwResultExt;
 use crate::SoftBufferError;
 use std::convert::TryInto;
+use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
 /// Display implementation for the web platform.
@@ -31,18 +36,40 @@ impl WebDisplayImpl {
     }
 }
 
-pub struct WebImpl {
-    /// The handle to the canvas that we're drawing to.
-    canvas: HtmlCanvasElement,
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = OffscreenCanvasRenderingContext2D)]
+    pub type OffscreenCanvasRenderingContext2d;
 
-    /// The 2D rendering context for the canvas.
-    ctx: CanvasRenderingContext2d,
+    #[wasm_bindgen(catch, method, structural, js_class = "OffscreenCanvasRenderingContext2D", js_name = putImageData)]
+    fn put_image_data(
+        this: &OffscreenCanvasRenderingContext2d,
+        imagedata: &ImageData,
+        dx: f64,
+        dy: f64,
+    ) -> Result<(), JsValue>;
+}
+
+pub struct WebImpl {
+    /// The handle and context to the canvas that we're drawing to.
+    canvas: Canvas,
 
     /// The buffer that we're drawing to.
     buffer: Vec<u32>,
 
     /// The current width of the canvas.
     width: u32,
+}
+
+pub enum Canvas {
+    Canvas {
+        canvas: HtmlCanvasElement,
+        ctx: CanvasRenderingContext2d,
+    },
+    OffscreenCanvas {
+        canvas: OffscreenCanvas,
+        ctx: OffscreenCanvasRenderingContext2d,
+    },
 }
 
 impl WebImpl {
@@ -56,22 +83,45 @@ impl WebImpl {
             // We already made sure this was a canvas in `querySelector`.
             .unchecked_into();
 
-        let ctx = canvas
-            .get_context("2d")
-            .ok()
+        Self::from_canvas(canvas)
+    }
+
+    fn from_canvas(canvas: HtmlCanvasElement) -> Result<Self, SoftBufferError> {
+        let ctx = Self::resolve_ctx(canvas.get_context("2d").ok(), "CanvasRenderingContext2d")?;
+
+        Ok(Self {
+            canvas: Canvas::Canvas { canvas, ctx },
+            buffer: Vec::new(),
+            width: 0,
+        })
+    }
+
+    fn from_offscreen_canvas(canvas: OffscreenCanvas) -> Result<Self, SoftBufferError> {
+        let ctx = Self::resolve_ctx(
+            canvas.get_context("2d").ok(),
+            "OffscreenCanvasRenderingContext2d",
+        )?;
+
+        Ok(Self {
+            canvas: Canvas::OffscreenCanvas { canvas, ctx },
+            buffer: Vec::new(),
+            width: 0,
+        })
+    }
+
+    fn resolve_ctx<T: JsCast>(
+        result: Option<Option<Object>>,
+        name: &str,
+    ) -> Result<T, SoftBufferError> {
+        let ctx = result
             .swbuf_err("Canvas already controlled using `OffscreenCanvas`")?
             .swbuf_err(
                 "A canvas context other than `CanvasRenderingContext2d` was already created",
             )?
             .dyn_into()
-            .expect("`getContext(\"2d\") didn't return a `CanvasRenderingContext2d`");
+            .unwrap_or_else(|_| panic!("`getContext(\"2d\") didn't return a `{name}`"));
 
-        Ok(Self {
-            canvas,
-            ctx,
-            buffer: Vec::new(),
-            width: 0,
-        })
+        Ok(ctx)
     }
 
     /// Resize the canvas to the given dimensions.
@@ -93,6 +143,58 @@ impl WebImpl {
     /// Get a pointer to the mutable buffer.
     pub(crate) fn buffer_mut(&mut self) -> Result<BufferImpl, SoftBufferError> {
         Ok(BufferImpl { imp: self })
+    }
+}
+
+/// Extension methods for the Wasm target on [`Surface`](crate::Surface).
+pub trait SurfaceExtWeb: Sized {
+    /// Creates a new instance of this struct, using the provided [`HtmlCanvasElement`].
+    fn from_canvas(canvas: HtmlCanvasElement) -> Result<Self, SoftBufferError>;
+
+    /// Creates a new instance of this struct, using the provided [`HtmlCanvasElement`].
+    fn from_offscreen_canvas(offscreen_canvas: OffscreenCanvas) -> Result<Self, SoftBufferError>;
+}
+
+impl SurfaceExtWeb for crate::Surface {
+    fn from_canvas(canvas: HtmlCanvasElement) -> Result<Self, SoftBufferError> {
+        let imple = crate::SurfaceDispatch::Web(WebImpl::from_canvas(canvas)?);
+
+        Ok(Self {
+            surface_impl: Box::new(imple),
+            _marker: PhantomData,
+        })
+    }
+
+    fn from_offscreen_canvas(offscreen_canvas: OffscreenCanvas) -> Result<Self, SoftBufferError> {
+        let imple = crate::SurfaceDispatch::Web(WebImpl::from_offscreen_canvas(offscreen_canvas)?);
+
+        Ok(Self {
+            surface_impl: Box::new(imple),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl Canvas {
+    fn set_width(&self, width: u32) {
+        match self {
+            Self::Canvas { canvas, .. } => canvas.set_width(width),
+            Self::OffscreenCanvas { canvas, .. } => canvas.set_width(width),
+        }
+    }
+
+    fn set_height(&self, height: u32) {
+        match self {
+            Self::Canvas { canvas, .. } => canvas.set_height(height),
+            Self::OffscreenCanvas { canvas, .. } => canvas.set_height(height),
+        }
+    }
+
+    fn put_image_data(&self, imagedata: &ImageData, dx: f64, dy: f64) -> Result<(), JsValue> {
+        match self {
+            Self::Canvas { ctx, .. } => ctx.put_image_data(imagedata, dx, dy),
+            Self::OffscreenCanvas { ctx, .. } => ctx.put_image_data(imagedata, dx, dy),
+        }
     }
 }
 
@@ -123,8 +225,6 @@ impl<'a> BufferImpl<'a> {
         #[cfg(target_feature = "atomics")]
         let result = {
             use js_sys::{Uint8Array, Uint8ClampedArray};
-            use wasm_bindgen::prelude::wasm_bindgen;
-            use wasm_bindgen::JsValue;
 
             #[wasm_bindgen]
             extern "C" {
@@ -149,7 +249,10 @@ impl<'a> BufferImpl<'a> {
         let image_data = result.unwrap();
 
         // This can only throw an error if `data` is detached, which is impossible.
-        self.imp.ctx.put_image_data(&image_data, 0.0, 0.0).unwrap();
+        self.imp
+            .canvas
+            .put_image_data(&image_data, 0.0, 0.0)
+            .unwrap();
 
         Ok(())
     }


### PR DESCRIPTION
> Added methods to create `Surface` from a `HtmlCanvasElement` or `OffscreenCanvas` following wgpu's example https://github.com/gfx-rs/wgpu/blob/v0.15.1/wgpu/src/lib.rs#L1570-L1640
> 
> My use case required this to render in a web worker.
> 
> Edit: See this for a future alternative implementation [rust-windowing/raw-window-handle#102](https://github.com/rust-windowing/raw-window-handle/issues/102)

This PR addresses the issues in #74 and additionally handles an error when using `OffscreenCanvas`, which has a different context type: `OffscreenCanvasRenderingContext2d`. It was assumed that it inherits from `CanvasRenderingContext2d`, which it does not, see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D).

I spoke to @Toniman575 after we discussed some issues, he told me to replace his PR instead.

Replaces #74.