### PR TITLE
Fix multi-threaded Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,14 @@ jobs:
           # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
           # doesn't currently work on Linux.
           - { target: wasm32-unknown-unknown,   os: windows-latest,  }
+        include:
+          - rust_version: nightly
+          - { target: wasm32-unknown-unknown,   os: windows-latest, options: -Zbuild-std=panic_abort,std, rustflags: -Ctarget-feature=+atomics }
 
     env:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
-      RUSTFLAGS: "-C debuginfo=0 --deny warnings"
+      RUSTFLAGS: "-C debuginfo=0 --deny warnings ${{ matrix.platform.rustflags }}"
       OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
       CMD: ${{ matrix.platform.cmd }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ foreign-types = "0.3.0"
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.55"
 wasm-bindgen = "0.2.78"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]


### PR DESCRIPTION
When I tried actually using Softbuffer with #76 in a multi-threaded Wasm environment using [`transferControlToOffscreen()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen) I found that Softbuffer actually fails on `ImageData::new_with_u8_clamped_array(wasm_bindgen::Clamped(&bitmap), width.into())`.

Apparently it is not allowed to create a `ImageData` from a `SharedArrayBuffer`. I only found a couple of Stackoverflow issues facing this ([#1](https://stackoverflow.com/questions/60911099), [#2](https://stackoverflow.com/questions/66827434)) but no actual documentation on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/ImageData) or [WHATWG](https://html.spec.whatwg.org/multipage/canvas.html#initialize-an-imagedata-object).

This fixes it by copying the data to a `Uint8Array` first and then creating the `ImageData` from that. Which is an extra copy that can't be avoided when using multi-threaded Wasm. I hid it all behind `#[cfg(target_feature = "atomics")]` to make sure not to affect people not needing this.

~~This can be further optimized by keeping the `Uint8Array` and not having to recreate it from scratch again every time. I thought maybe we should wait for #65 before that, happy to add it now if desired.~~
This could be further optimized if we add an additional function for Web that uses a copy API instead of the currently owned buffer one.

To make this happen I had to do an import by hand because `web-sys` doesn't actually provide the constructors we need for [`ImageData`](https://docs.rs/web-sys/0.3.61/web_sys/struct.ImageData.html#method.new_with_u8_clamped_array).

I also added `-Ctarget-feature=+atomics` to the CI separately to the regular Wasm build.

See the [`wasm-bindgen` documentation](https://rustwasm.github.io/docs/wasm-bindgen/examples/raytrace.html) for more information on multi-threaded Wasm.

This can be run locally with `RUSTFLAGS=-Ctarget-feature=+atomics,+bulk-memory cargo +nightly run-wasm --example winit -Zbuild-std=panic_abort,std`.