### PR TITLE
feat: Use the safer API for window handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,5 @@ members = [
 ]
 
 [patch.crates-io]
-raw-window-handle = { git = "https://github.com/notgull/raw-window-handle.git", branch = "notgull/impl-more", version = "0.5.1" }
+raw-window-handle = { git = "https://github.com/rust-windowing/raw-window-handle.git", version = "0.5.1" }
 winit = { git = "https://github.com/bread-graphics/winit.git", branch = "window-handle", version = "0.28.3" }
-
-[patch.'https://github.com/rust-windowing/raw-window-handle']
-raw-window-handle = { git = "https://github.com/notgull/raw-window-handle.git", branch = "notgull/impl-more", version = "0.5.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ x11 = ["bytemuck", "nix", "x11rb", "x11-dl"]
 
 [dependencies]
 log = "0.4.17"
-raw-window-handle = { version = "0.5.0", features = ["alloc"] }
+raw-window-handle = { version = "0.5.0", features = ["std"] }
 thiserror = "1.0.30"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,5 +79,4 @@ members = [
 ]
 
 [patch.crates-io]
-raw-window-handle = { git = "https://github.com/rust-windowing/raw-window-handle.git", version = "0.5.1", branch = "notgull/change-actie" }
 winit = { git = "https://github.com/bread-graphics/winit.git", branch = "window-handle", version = "0.28.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,5 +79,5 @@ members = [
 ]
 
 [patch.crates-io]
-raw-window-handle = { git = "https://github.com/rust-windowing/raw-window-handle.git", version = "0.5.1" }
+raw-window-handle = { git = "https://github.com/rust-windowing/raw-window-handle.git", version = "0.5.1", branch = "notgull/change-actie" }
 winit = { git = "https://github.com/bread-graphics/winit.git", branch = "window-handle", version = "0.28.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ x11 = ["bytemuck", "nix", "x11rb", "x11-dl"]
 
 [dependencies]
 log = "0.4.17"
-raw-window-handle = "0.5.0"
+raw-window-handle = { version = "0.5.0", features = ["alloc"] }
 thiserror = "1.0.30"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
@@ -77,3 +77,10 @@ rayon = "1.5.1"
 members = [
     "run-wasm",
 ]
+
+[patch.crates-io]
+raw-window-handle = { git = "https://github.com/notgull/raw-window-handle.git", branch = "notgull/impl-more", version = "0.5.1" }
+winit = { git = "https://github.com/bread-graphics/winit.git", branch = "window-handle", version = "0.28.3" }
+
+[patch.'https://github.com/rust-windowing/raw-window-handle']
+raw-window-handle = { git = "https://github.com/notgull/raw-window-handle.git", branch = "notgull/impl-more", version = "0.5.1" }

--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ To run an example with the web backend: `cargo run-wasm --example winit`
 Example
 ==
 ```rust,no_run
+use std::rc::Rc;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 
 fn main() {
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
-    let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
-    let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
+    let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let context = softbuffer::Context::new(Rc::clone(&window)).unwrap();
+    let mut surface = softbuffer::Surface::new(&context, Rc::clone(&window)).unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -2,13 +2,14 @@ use instant::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 use std::f64::consts::PI;
+use std::rc::Rc;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 
 fn main() {
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -24,8 +25,12 @@ fn main() {
             .unwrap();
     }
 
-    let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
-    let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
+    let (context, mut surface) = {
+        let context = softbuffer::Context::new(window.clone()).unwrap();
+        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        (context, surface)
+    };
 
     let mut old_size = (0, 0);
     let mut frames = pre_render_frames(0, 0);
@@ -48,7 +53,7 @@ fn main() {
                 };
 
                 let buffer = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
-                surface.set_buffer(buffer.as_slice(), width as u16, height as u16);
+                surface.set_buffer(&context, buffer.as_slice(), width as u16, height as u16);
             }
             Event::MainEventsCleared => {
                 window.request_redraw();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -53,7 +53,7 @@ fn main() {
                 };
 
                 let buffer = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
-                surface.set_buffer(&context, buffer.as_slice(), width as u16, height as u16);
+                surface.set_buffer(buffer.as_slice(), width as u16, height as u16);
             }
             Event::MainEventsCleared => {
                 window.request_redraw();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -25,12 +25,8 @@ fn main() {
             .unwrap();
     }
 
-    let (context, mut surface) = {
-        let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
-
-        (context, surface)
-    };
+    let context = softbuffer::Context::new(window.clone()).unwrap();
+    let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
 
     let mut old_size = (0, 0);
     let mut frames = pre_render_frames(0, 0);

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -48,12 +48,7 @@ fn main() {
 
         match event {
             Event::RedrawRequested(window_id) if window_id == window.id() => {
-                surface.set_buffer(
-                    &context,
-                    &buffer,
-                    fruit.width() as u16,
-                    fruit.height() as u16,
-                );
+                surface.set_buffer(&buffer, fruit.width() as u16, fruit.height() as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -69,7 +69,7 @@ fn main() {
                 redraw(&mut buffer, width, height, flag);
 
                 // Blit the offscreen buffer to the window's client area
-                surface.set_buffer(&context, &buffer, width as u16, height as u16);
+                surface.set_buffer(&buffer, width as u16, height as u16);
             }
 
             Event::WindowEvent {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -21,10 +22,12 @@ fn redraw(buffer: &mut [u32], width: usize, height: usize, flag: bool) {
 fn main() {
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("Press space to show/hide a rectangle")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Press space to show/hide a rectangle")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -40,8 +43,8 @@ fn main() {
             .unwrap();
     }
 
-    let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
-    let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
+    let context = softbuffer::Context::new(window.clone()).unwrap();
+    let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
 
     let mut buffer = Vec::new();
     let mut flag = false;
@@ -66,7 +69,7 @@ fn main() {
                 redraw(&mut buffer, width, height, flag);
 
                 // Blit the offscreen buffer to the window's client area
-                surface.set_buffer(&buffer, width as u16, height as u16);
+                surface.set_buffer(&context, &buffer, width as u16, height as u16);
             }
 
             Event::WindowEvent {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -47,7 +47,7 @@ fn main() {
                     })
                     .collect::<Vec<_>>();
 
-                surface.set_buffer(&context, &buffer, width as u16, height as u16);
+                surface.set_buffer(&buffer, width as u16, height as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -1,10 +1,11 @@
+use std::rc::Rc;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 
 fn main() {
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -20,8 +21,8 @@ fn main() {
             .unwrap();
     }
 
-    let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
-    let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
+    let context = softbuffer::Context::new(window.clone()).unwrap();
+    let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -46,7 +47,7 @@ fn main() {
                     })
                     .collect::<Vec<_>>();
 
-                surface.set_buffer(&buffer, width as u16, height as u16);
+                surface.set_buffer(&context, &buffer, width as u16, height as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -46,7 +46,7 @@ fn main() {
                     })
                     .collect::<Vec<_>>();
 
-                surface.set_buffer(&context, &buffer, BUFFER_WIDTH as u16, BUFFER_HEIGHT as u16);
+                surface.set_buffer(&buffer, BUFFER_WIDTH as u16, BUFFER_HEIGHT as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -7,7 +8,7 @@ const BUFFER_HEIGHT: usize = 128;
 
 fn main() {
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -23,8 +24,8 @@ fn main() {
             .unwrap();
     }
 
-    let context = unsafe { softbuffer::Context::new(&window) }.unwrap();
-    let mut surface = unsafe { softbuffer::Surface::new(&context, &window) }.unwrap();
+    let context = softbuffer::Context::new(window.clone()).unwrap();
+    let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -45,7 +46,7 @@ fn main() {
                     })
                     .collect::<Vec<_>>();
 
-                surface.set_buffer(&buffer, BUFFER_WIDTH as u16, BUFFER_HEIGHT as u16);
+                surface.set_buffer(&context, &buffer, BUFFER_WIDTH as u16, BUFFER_HEIGHT as u16);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum SoftBufferError {
     #[error("The provided display handle is null.")]
     IncompleteDisplayHandle,
 
+    #[error("The provided display handle is not active.")]
+    Inactive,
+
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
+use raw_window_handle::{HandleError, RawDisplayHandle, RawWindowHandle};
 use std::error::Error;
 use thiserror::Error;
 
@@ -27,8 +27,8 @@ pub enum SoftBufferError {
     #[error("The provided display handle is null.")]
     IncompleteDisplayHandle,
 
-    #[error("The provided display handle is not active.")]
-    Inactive,
+    #[error("A handle error occurred: {0}")]
+    HandleError(#[from] HandleError),
 
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle + ?Sized> Surface<D, W> {
                 }
             };
 
+        drop(raw_window_handle);
+
         Ok(Self {
             surface_impl: Box::new(imple),
             window,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl<D: HasDisplayHandle + ?Sized> Context<D> {
     where
         D: Sized,
     {
-        let imple: ContextDispatch = match display.display_handle().raw_display_handle() {
+        let imple: ContextDispatch = match display.display_handle()?.raw_display_handle() {
             #[cfg(x11_platform)]
             RawDisplayHandle::Xlib(xlib_handle) => unsafe {
                 ContextDispatch::X11(Arc::new(x11::X11DisplayImpl::from_xlib(xlib_handle)?))
@@ -177,7 +177,7 @@ impl<W: HasWindowHandle + ?Sized> Surface<W> {
     where
         W: Sized,
     {
-        let raw_window_handle = window.window_handle().unwrap();
+        let raw_window_handle = window.window_handle()?;
         let imple: SurfaceDispatch =
             match (&context.context_impl, raw_window_handle.raw_window_handle()) {
                 #[cfg(x11_platform)]


### PR DESCRIPTION
Builds on rust-windowing/raw-window-handle#110, rust-windowing/raw-window-handle#115 and rust-windowing/winit#2744 to see how the new safe raw window API does ergonomically.