### PR TITLE
Add `Buffer::present_with_damage()` and `Buffer::age()`

### DIFF
--- a/src/cg.rs
+++ b/src/cg.rs
@@ -87,6 +87,10 @@ impl<'a> BufferImpl<'a> {
         &mut self.buffer
     }
 
+    pub fn age(&self) -> u8 {
+        0
+    }
+
     pub fn present(self) -> Result<(), SoftBufferError> {
         let data_provider = CGDataProvider::from_buffer(Arc::new(Buffer(self.buffer)));
         let image = CGImage::new(

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,4 +1,4 @@
-use crate::SoftBufferError;
+use crate::{Rect, SoftBufferError};
 use core_graphics::base::{
     kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault,
 };
@@ -118,6 +118,10 @@ impl<'a> BufferImpl<'a> {
         transaction::commit();
 
         Ok(())
+    }
+
+    pub fn present_with_damage(self, _damage: &[Rect]) -> Result<(), SoftBufferError> {
+        self.present()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,11 @@ pub enum SoftBufferError {
         height: NonZeroU32,
     },
 
+    #[error(
+        "Damage rect {}x{} at ({}, {}) out of range for backend.", .rect.width, .rect.height, .rect.x, .rect.y,
+    )]
+    DamageOutOfRange { rect: crate::Rect },
+
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,15 @@ macro_rules! make_dispatch {
                 }
             }
 
+            pub fn age(&self) -> u8 {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.age(),
+                    )*
+                }
+            }
+
             pub fn present(self) -> Result<(), SoftBufferError> {
                 match self {
                     $(
@@ -326,7 +335,7 @@ impl Surface {
 
     /// Return a [`Buffer`] that the next frame should be rendered into. The size must
     /// be set with [`Surface::resize`] first. The initial contents of the buffer may be zeroed, or
-    /// may contain a previous frame.
+    /// may contain a previous frame. Call [`Buffer::age`] to determine this.
     pub fn buffer_mut(&mut self) -> Result<Buffer, SoftBufferError> {
         Ok(Buffer {
             buffer_impl: self.surface_impl.buffer_mut()?,
@@ -377,6 +386,16 @@ pub struct Buffer<'a> {
 }
 
 impl<'a> Buffer<'a> {
+    /// Is age is the number of frames ago this buffer was last presented. So if the value is
+    /// `1`, it is the same as the last frame, and if it is `2`, it is the same as the frame
+    /// before that (for backends using double buffering). If the value is `0`, it is a new
+    /// buffer that has unspecified contents.
+    ///
+    /// This can be used to update only a portion of the buffer.
+    pub fn age(&self) -> u8 {
+        self.buffer_impl.age()
+    }
+
     /// Presents buffer to the window.
     ///
     /// # Platform dependent behavior

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,13 +233,13 @@ impl Context {
 #[derive(Clone, Copy, Debug)]
 pub struct Rect {
     /// x coordinate of top left corner
-    pub x: i32,
+    pub x: u32,
     /// y coordinate of top left corner
-    pub y: i32,
+    pub y: u32,
     /// width
-    pub width: i32,
+    pub width: NonZeroU32,
     /// height
-    pub height: i32,
+    pub height: NonZeroU32,
 }
 
 /// A surface for drawing to a window with software buffers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,15 @@ macro_rules! make_dispatch {
                     )*
                 }
             }
+
+            pub fn present_with_damage(self, damage: &[Rect]) -> Result<(), SoftBufferError> {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.present_with_damage(damage),
+                    )*
+                }
+            }
         }
     };
 }
@@ -205,6 +214,19 @@ impl Context {
             _marker: PhantomData,
         })
     }
+}
+
+/// A rectangular region of the buffer coordinate space.
+#[derive(Clone, Copy, Debug)]
+pub struct Rect {
+    /// x coordinate of top left corner
+    pub x: i32,
+    /// y coordinate of top left corner
+    pub y: i32,
+    /// width
+    pub width: i32,
+    /// height
+    pub height: i32,
 }
 
 /// A surface for drawing to a window with software buffers.
@@ -369,6 +391,20 @@ impl<'a> Buffer<'a> {
     /// Wayland compositor before calling this function.
     pub fn present(self) -> Result<(), SoftBufferError> {
         self.buffer_impl.present()
+    }
+
+    /// Presents buffer to the window, with damage regions.
+    ///
+    /// # Platform dependent behavior
+    ///
+    /// Supported on:
+    /// - Wayland
+    /// - X, when XShm is available
+    /// - Win32
+    ///
+    /// Otherwise this is equivalent to [`present`].
+    pub fn present_with_damage(self, damage: &[Rect]) -> Result<(), SoftBufferError> {
+        self.buffer_impl.present_with_damage(damage)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ impl<'a> Buffer<'a> {
     /// - X, when XShm is available
     /// - Win32
     ///
-    /// Otherwise this is equivalent to [`present`].
+    /// Otherwise this is equivalent to [`Self::present`].
     pub fn present_with_damage(self, damage: &[Rect]) -> Result<(), SoftBufferError> {
         self.buffer_impl.present_with_damage(damage)
     }

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -1,7 +1,7 @@
 use raw_window_handle::OrbitalWindowHandle;
 use std::{cmp, num::NonZeroU32, slice, str};
 
-use crate::SoftBufferError;
+use crate::{Rect, SoftBufferError};
 
 struct OrbitalMap {
     address: usize,
@@ -185,5 +185,9 @@ impl<'a> BufferImpl<'a> {
         }
 
         Ok(())
+    }
+
+    pub fn present_with_damage(self, _damage: &[Rect]) -> Result<(), SoftBufferError> {
+        self.present()
     }
 }

--- a/src/wayland/buffer.rs
+++ b/src/wayland/buffer.rs
@@ -90,6 +90,7 @@ pub(super) struct WaylandBuffer {
     width: i32,
     height: i32,
     released: Arc<AtomicBool>,
+    pub age: u8,
 }
 
 impl WaylandBuffer {
@@ -125,6 +126,7 @@ impl WaylandBuffer {
             width,
             height,
             released,
+            age: 0,
         }
     }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -9,7 +9,7 @@ use web_sys::HtmlCanvasElement;
 use web_sys::ImageData;
 
 use crate::error::SwResultExt;
-use crate::SoftBufferError;
+use crate::{Rect, SoftBufferError};
 use std::convert::TryInto;
 use std::num::NonZeroU32;
 
@@ -152,6 +152,10 @@ impl<'a> BufferImpl<'a> {
         self.imp.ctx.put_image_data(&image_data, 0.0, 0.0).unwrap();
 
         Ok(())
+    }
+
+    pub fn present_with_damage(self, _damage: &[Rect]) -> Result<(), SoftBufferError> {
+        self.present()
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-windowing/softbuffer/issues/39.

Implemented only for Wayland. Should be able to add an X implementation using `XDamage`, but I haven't looked at how that works yet. On `web` we could use this to update only the changed part of the canvas possibly. If we need to convert the format anyway. I don't see any API for damage that could be used on macOS or Windows.

Also should be tested in some way.