### PR TITLE
x11: Limit returned shm buffer size

### DIFF
--- a/src/x11.rs
+++ b/src/x11.rs
@@ -540,6 +540,8 @@ struct ShmSegment {
 impl ShmSegment {
     /// Create a new `ShmSegment` with the given size.
     fn new(size: usize, buffer_size: usize) -> io::Result<Self> {
+        assert!(size >= buffer_size);
+
         unsafe {
             // Create the shared memory segment.
             let id = shmget(IPC_PRIVATE, size, 0o600);
@@ -588,6 +590,7 @@ impl ShmSegment {
 
     /// Set the size of the buffer for this shared memory segment.
     fn set_buffer_size(&mut self, buffer_size: usize) {
+        assert!(self.size >= buffer_size);
         self.buffer_size = buffer_size
     }
 


### PR DESCRIPTION
When attempting to resize the buffer on X11 using shm, the buffer returned by `buffer_mut()` would be larger than the larger than requested, causing a panic if `copy_from_slice` was used:
```
thread 'main' panicked at 'source slice length (480000) does not match destination slice length (524288)', examples/animation.rs:60:24
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7908a1d65496b88626e4b7c193c81d777005d6f3/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/7908a1d65496b88626e4b7c193c81d777005d6f3/library/core/src/panicking.rs:67:14
   2: core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail
             at /rustc/7908a1d65496b88626e4b7c193c81d777005d6f3/library/core/src/slice/mod.rs:3341:13
   3: core::slice::<impl [T]>::copy_from_slice
             at /rustc/7908a1d65496b88626e4b7c193c81d777005d6f3/library/core/src/slice/mod.rs:3348:13
   4: animation::main::{{closure}}
             at ./examples/animation.rs:60:17
   5: winit::platform_impl::platform::sticky_exit_callback
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/platform_impl/linux/mod.rs:884:9
   6: winit::platform_impl::platform::x11::EventLoop<T>::run_return::single_iteration
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/platform_impl/linux/x11/mod.rs:375:21
   7: winit::platform_impl::platform::x11::EventLoop<T>::run_return
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/platform_impl/linux/x11/mod.rs:443:31
   8: winit::platform_impl::platform::x11::EventLoop<T>::run
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/platform_impl/linux/x11/mod.rs:498:25
   9: winit::platform_impl::platform::EventLoop<T>::run
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/platform_impl/linux/mod.rs:792:56
  10: winit::event_loop::EventLoop<T>::run
             at /test/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.3/src/event_loop.rs:305:9
  11: animation::main
             at ./examples/animation.rs:35:5
```

This PR fixes that by storing the requested buffer size in `ShmSegment`, and then returning a sub-slice of the shm in `ShmBuffer::as_ref` and `ShmBuffer::as_mut`.