### PR TITLE
Add @daxpedda as web maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 # Wayland
 /src/wayland        @ids1024
 
-# Web (no maintainer)
-/src/web.rs
+# Web
+/src/web.rs         @daxpedda
 
 # Windows
 /src/win32.rs       @notgull


### PR DESCRIPTION
Hello @daxpedda,

Given that you've been practically maintaining the web backend for this crate (#76, #77, #87, #101), and that we don't have a web maintainer yet, would you like to be this crate's web maintainer? You seem knowledgeable enough about the web and WASM to fit the bill.

If so, let me know, and we can add you to @rust-windowing/softbuffer.