### PR TITLE
Add a function for retrieving the window contents

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 run-wasm = ["run", "--release", "--package", "run-wasm", "--"]
+
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         !contains(matrix.platform.target, 'linux')
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
+    # TODO: We should also be using Wayland for testing here.
     - name: Run tests using Xvfb
       shell: bash
       if: >
@@ -116,7 +117,9 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         !contains(matrix.platform.target, 'freebsd') &&
         !contains(matrix.platform.target, 'netbsd') &&
-        contains(matrix.platform.target, 'linux')
+        contains(matrix.platform.target, 'linux') &&
+        !contains(matrix.platform.options, '--no-default-features') &&
+        !contains(matrix.platform.features, 'wayland')
       run: xvfb-run cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Lint with clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,19 @@ jobs:
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
         !contains(matrix.platform.target, 'freebsd') &&
-        !contains(matrix.platform.target, 'netbsd')
+        !contains(matrix.platform.target, 'netbsd') &&
+        !contains(matrix.platform.target, 'linux')
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+
+    - name: Run tests using Xvfb
+      shell: bash
+      if: >
+        !((matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')) &&
+        !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'freebsd') &&
+        !contains(matrix.platform.target, 'netbsd') &&
+        contains(matrix.platform.target, 'linux')
+      run: xvfb-run cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Lint with clippy
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,10 @@ jobs:
           - { target: x86_64-unknown-freebsd,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-netbsd,    os: ubuntu-latest,   }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
-          # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
-          # doesn't currently work on Linux.
-          - { target: wasm32-unknown-unknown,   os: windows-latest,  }
+          - { target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
         include:
           - rust_version: nightly
-            platform: { target: wasm32-unknown-unknown, os: windows-latest, options: "-Zbuild-std=panic_abort,std", rustflags: "-Ctarget-feature=+atomics,+bulk-memory" }
+            platform: { target: wasm32-unknown-unknown, os: ubuntu-latest, options: "-Zbuild-std=panic_abort,std", rustflags: "-Ctarget-feature=+atomics,+bulk-memory" }
 
     env:
       RUST_BACKTRACE: 1
@@ -67,12 +65,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # Used to cache cargo-web
-    - name: Cache cargo folder
-      uses: actions/cache@v3
+    - uses: taiki-e/install-action@v2
+      if: matrix.platform.target == 'wasm32-unknown-unknown'
       with:
-        path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ matrix.rust_version }}
+        tool: wasm-bindgen-cli
 
     - uses: hecrj/setup-rust-action@v1
       with:
@@ -102,7 +98,6 @@ jobs:
       shell: bash
       if: >
         !((matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')) &&
-        !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
         !contains(matrix.platform.target, 'freebsd') &&
         !contains(matrix.platform.target, 'netbsd') &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ features = ["jpeg"]
 image = "0.24.6"
 rayon = "1.5.1"
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [workspace]
 members = [
     "run-wasm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ cfg_aliases = "0.1.1"
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 instant = "0.1.12"
 winit = "0.28.1"
+winit-test = "0.1.0"
 
 [dev-dependencies.image]
 version = "0.24.6"
@@ -85,6 +86,11 @@ rayon = "1.5.1"
 members = [
     "run-wasm",
 ]
+
+[[test]]
+name = "present_and_fetch"
+path = "tests/present_and_fetch.rs"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -72,7 +72,7 @@ impl CGImpl {
 
     /// Fetch the buffer from the window.
     pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
-        todo!()
+        Err(SoftBufferError::Unimplemented)
     }
 }
 

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -119,6 +119,11 @@ impl<'a> BufferImpl<'a> {
 
         Ok(())
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }
 
 impl Drop for CGImpl {

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -69,6 +69,11 @@ impl CGImpl {
             imp: self,
         })
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+        todo!()
+    }
 }
 
 pub struct BufferImpl<'a> {
@@ -118,11 +123,6 @@ impl<'a> BufferImpl<'a> {
         transaction::commit();
 
         Ok(())
-    }
-
-    /// Fetch the buffer from the window.
-    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-        todo!()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum SoftBufferError {
 
     #[error("Platform error")]
     PlatformError(Option<String>, Option<Box<dyn Error>>),
+
+    #[error("This function is unimplemented on this platform")]
+    Unimplemented,
 }
 
 /// Convenient wrapper to cast errors into SoftBufferError.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,15 @@ macro_rules! make_dispatch {
                     )*
                 }
             }
+
+            pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.fetch(),
+                    )*
+                }
+            }
         }
     };
 }
@@ -373,6 +382,11 @@ impl<'a> Buffer<'a> {
     /// Wayland compositor before calling this function.
     pub fn present(self) -> Result<(), SoftBufferError> {
         self.buffer_impl.present()
+    }
+
+    /// Copies the window contents into this buffer.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        self.buffer_impl.fetch()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,8 @@ impl Surface {
     ///
     /// - On X11, the window must be visible.
     /// - On macOS, Redox and Wayland, this function is unimplemented.
+    /// - On Web, this will fail if the content was supplied by
+    ///   a different origin depending on the sites CORS rules.
     pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
         self.surface_impl.fetch()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,7 @@ impl Surface {
     /// ## Platform Dependent Behavior
     ///
     /// - On X11, the window must be visible.
+    /// - On macOS, Redox and Wayland, this function is unimplemented.
     pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
         self.surface_impl.fetch()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,15 @@ macro_rules! make_dispatch {
                     )*
                 }
             }
+
+            pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.fetch(),
+                    )*
+                }
+            }
         }
 
         enum BufferDispatch<'a> {
@@ -133,15 +142,6 @@ macro_rules! make_dispatch {
                     $(
                         $(#[$attr])*
                         Self::$name(inner) => inner.present(),
-                    )*
-                }
-            }
-
-            pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-                match self {
-                    $(
-                        $(#[$attr])*
-                        Self::$name(inner) => inner.fetch(),
                     )*
                 }
             }
@@ -315,6 +315,15 @@ impl Surface {
         self.surface_impl.resize(width, height)
     }
 
+    /// Copies the window contents into a buffer.
+    ///
+    /// ## Platform Dependent Behavior
+    ///
+    /// - On X11, the window must be visible.
+    pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+        self.surface_impl.fetch()
+    }
+
     /// Return a [`Buffer`] that the next frame should be rendered into. The size must
     /// be set with [`Surface::resize`] first. The initial contents of the buffer may be zeroed, or
     /// may contain a previous frame.
@@ -382,11 +391,6 @@ impl<'a> Buffer<'a> {
     /// Wayland compositor before calling this function.
     pub fn present(self) -> Result<(), SoftBufferError> {
         self.buffer_impl.present()
-    }
-
-    /// Copies the window contents into this buffer.
-    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-        self.buffer_impl.fetch()
     }
 }
 

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -143,6 +143,11 @@ impl OrbitalImpl {
         // Tell orbital to show the latest window data
         syscall::fsync(self.window_fd()).expect("failed to sync orbital window");
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }
 
 enum Pixels {

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -145,7 +145,7 @@ impl OrbitalImpl {
     }
 
     /// Fetch the buffer from the window.
-    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+    pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
         todo!()
     }
 }

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -146,7 +146,7 @@ impl OrbitalImpl {
 
     /// Fetch the buffer from the window.
     pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
-        todo!()
+        Err(SoftBufferError::Unimplemented)
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -132,7 +132,7 @@ impl WaylandImpl {
 
     /// Fetch the buffer from the window.
     pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
-        todo!()
+        Err(SoftBufferError::Unimplemented)
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -129,6 +129,11 @@ impl WaylandImpl {
             Ok(unsafe { buffer.buffers.as_mut().unwrap().1.mapped_mut() })
         })?))
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+        todo!()
+    }
 }
 
 pub struct BufferImpl<'a>(util::BorrowStack<'a, WaylandImpl, [u32]>);
@@ -183,11 +188,6 @@ impl<'a> BufferImpl<'a> {
         let _ = imp.display.event_queue.borrow_mut().flush();
 
         Ok(())
-    }
-
-    /// Fetch the buffer from the window.
-    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-        todo!()
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -184,6 +184,11 @@ impl<'a> BufferImpl<'a> {
 
         Ok(())
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {

--- a/src/web.rs
+++ b/src/web.rs
@@ -175,6 +175,11 @@ impl<'a> BufferImpl<'a> {
 
         Ok(())
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }
 
 #[inline(always)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -126,6 +126,10 @@ impl WebImpl {
 /// Extension methods for the Wasm target on [`Surface`](crate::Surface).
 pub trait SurfaceExtWeb: Sized {
     /// Creates a new instance of this struct, using the provided [`HtmlCanvasElement`].
+    ///
+    /// # Errors
+    /// - If the canvas was already controlled by an `OffscreenCanvas`.
+    /// - If a another context then "2d" was already created for this canvas.
     fn from_canvas(canvas: HtmlCanvasElement) -> Result<Self, SoftBufferError>;
 }
 

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -202,6 +202,29 @@ impl Win32Impl {
 
         Ok(BufferImpl(self))
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+        let buffer = self.buffer.as_ref().unwrap();
+        let temp_buffer = Buffer::new(self.dc, buffer.width, buffer.height);
+
+        // Just go the other way.
+        unsafe {
+            Gdi::BitBlt(
+                temp_buffer.dc,
+                0,
+                0,
+                temp_buffer.width.get(),
+                temp_buffer.height.get(),
+                self.dc,
+                0,
+                0,
+                Gdi::SRCCOPY,
+            );
+        }
+
+        Ok(temp_buffer.pixels().to_vec())
+    }
 }
 
 pub struct BufferImpl<'a>(&'a mut Win32Impl);
@@ -235,29 +258,6 @@ impl<'a> BufferImpl<'a> {
 
             // Validate the window.
             Gdi::ValidateRect(imp.window, ptr::null_mut());
-        }
-
-        Ok(())
-    }
-
-    /// Fetch the buffer from the window.
-    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-        let imp = &mut self.0;
-        let buffer = imp.buffer.as_ref().unwrap();
-
-        // Just go the other way.
-        unsafe {
-            Gdi::BitBlt(
-                buffer.dc,
-                0,
-                0,
-                buffer.width.get(),
-                buffer.height.get(),
-                imp.dc,
-                0,
-                0,
-                Gdi::SRCCOPY,
-            );
         }
 
         Ok(())

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -239,4 +239,9 @@ impl<'a> BufferImpl<'a> {
 
         Ok(())
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -223,6 +223,11 @@ impl Win32Impl {
             );
         }
 
+        // Flush the operation so that it happens immediately.
+        unsafe {
+            Gdi::GdiFlush();
+        }
+
         Ok(temp_buffer.pixels().to_vec())
     }
 }

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -242,6 +242,24 @@ impl<'a> BufferImpl<'a> {
 
     /// Fetch the buffer from the window.
     pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
-        todo!()
+        let imp = &mut self.0;
+        let buffer = imp.buffer.as_ref().unwrap();
+
+        // Just go the other way.
+        unsafe {
+            Gdi::BitBlt(
+                buffer.dc,
+                0,
+                0,
+                buffer.width.get(),
+                buffer.height.get(),
+                imp.dc,
+                0,
+                0,
+                Gdi::SRCCOPY,
+            );
+        }
+
+        Ok(())
     }
 }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -684,7 +684,7 @@ impl ShmSegment {
 
         unsafe {
             // Create the shared memory segment.
-            let id = shmget(IPC_PRIVATE, size, 0o600);
+            let id = shmget(IPC_PRIVATE, size, 0o1777);
             if id == -1 {
                 return Err(io::Error::last_os_error());
             }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -361,6 +361,11 @@ impl<'a> BufferImpl<'a> {
 
         result.swbuf_err("Failed to draw image to window")
     }
+
+    /// Fetch the buffer from the window.
+    pub fn fetch(&mut self) -> Result<(), SoftBufferError> {
+        todo!()
+    }
 }
 
 impl Buffer {

--- a/tests/present_and_fetch.rs
+++ b/tests/present_and_fetch.rs
@@ -1,0 +1,39 @@
+use softbuffer::{Context, Surface};
+use std::num::NonZeroU32;
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use winit::event::Event;
+use winit::event_loop::{EventLoop, EventLoopWindowTarget};
+
+fn all_red(elwt: &EventLoopWindowTarget<()>) {
+    let window = winit::window::WindowBuilder::new()
+        .with_title("all_red")
+        .with_visible(false)
+        .build(elwt)
+        .unwrap();
+
+    let context = unsafe { Context::new(elwt) }.unwrap();
+    let mut surface = unsafe { Surface::new(&context, &window) }.unwrap();
+    let size = window.inner_size();
+
+    // Set the size of the surface to the size of the window.
+    surface.resize(
+        NonZeroU32::new(size.width).unwrap(),
+        NonZeroU32::new(size.height).unwrap(),
+    ).unwrap();
+
+    // Set all pixels to red.
+    let mut buffer = surface.buffer_mut().unwrap();
+    buffer.fill(0xFF0000FF);
+    buffer.present().unwrap();
+
+    // Check that all pixels are red.
+    let mut buffer = surface.buffer_mut().unwrap();
+    buffer.fetch().unwrap();
+    for pixel in buffer.iter() {
+        assert_eq!(*pixel, 0xFF0000FF);
+    }
+}
+
+winit_test::main!(all_red);

--- a/tests/present_and_fetch.rs
+++ b/tests/present_and_fetch.rs
@@ -1,38 +1,51 @@
 use softbuffer::{Context, Surface};
 use std::num::NonZeroU32;
-
-use std::panic::{catch_unwind, AssertUnwindSafe};
-
-use winit::event::Event;
-use winit::event_loop::{EventLoop, EventLoopWindowTarget};
+use winit::event_loop::EventLoopWindowTarget;
 
 fn all_red(elwt: &EventLoopWindowTarget<()>) {
     let window = winit::window::WindowBuilder::new()
         .with_title("all_red")
-        .with_visible(false)
         .build(elwt)
         .unwrap();
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use winit::platform::web::WindowExtWebSys;
+
+        web_sys::window()
+            .unwrap()
+            .document()
+            .unwrap()
+            .body()
+            .unwrap()
+            .append_child(&window.canvas())
+            .unwrap();
+    }
+
+    // winit does not wait for the window to be mapped... sigh
+    std::thread::sleep(std::time::Duration::from_millis(1));
 
     let context = unsafe { Context::new(elwt) }.unwrap();
     let mut surface = unsafe { Surface::new(&context, &window) }.unwrap();
     let size = window.inner_size();
 
     // Set the size of the surface to the size of the window.
-    surface.resize(
-        NonZeroU32::new(size.width).unwrap(),
-        NonZeroU32::new(size.height).unwrap(),
-    ).unwrap();
+    surface
+        .resize(
+            NonZeroU32::new(size.width).unwrap(),
+            NonZeroU32::new(size.height).unwrap(),
+        )
+        .unwrap();
 
     // Set all pixels to red.
     let mut buffer = surface.buffer_mut().unwrap();
-    buffer.fill(0xFF0000FF);
+    buffer.fill(0xFF000000);
     buffer.present().unwrap();
 
     // Check that all pixels are red.
-    let mut buffer = surface.buffer_mut().unwrap();
-    buffer.fetch().unwrap();
-    for pixel in buffer.iter() {
-        assert_eq!(*pixel, 0xFF0000FF);
+    let screen_contents = surface.fetch().unwrap();
+    for pixel in screen_contents.iter() {
+        assert_eq!(*pixel, 0xFF000000);
     }
 }
 

--- a/tests/present_and_fetch.rs
+++ b/tests/present_and_fetch.rs
@@ -40,7 +40,7 @@ fn all_red(elwt: &EventLoopWindowTarget<()>) {
 
     // Set all pixels to red.
     let mut buffer = surface.buffer_mut().unwrap();
-    buffer.fill(0xFF000000);
+    buffer.fill(0x00FF0000);
     buffer.present().unwrap();
 
     // Check that all pixels are red.
@@ -49,7 +49,7 @@ fn all_red(elwt: &EventLoopWindowTarget<()>) {
         cont => cont.unwrap(),
     };
     for pixel in screen_contents.iter() {
-        assert_eq!(*pixel, 0xFF000000);
+        assert_eq!(*pixel, 0x00FF0000);
     }
 }
 

--- a/tests/present_and_fetch.rs
+++ b/tests/present_and_fetch.rs
@@ -23,6 +23,7 @@ fn all_red(elwt: &EventLoopWindowTarget<()>) {
     }
 
     // winit does not wait for the window to be mapped... sigh
+    #[cfg(not(target_arch = "wasm32"))]
     std::thread::sleep(std::time::Duration::from_millis(1));
 
     let context = unsafe { Context::new(elwt) }.unwrap();
@@ -43,7 +44,10 @@ fn all_red(elwt: &EventLoopWindowTarget<()>) {
     buffer.present().unwrap();
 
     // Check that all pixels are red.
-    let screen_contents = surface.fetch().unwrap();
+    let screen_contents = match surface.fetch() {
+        Err(softbuffer::SoftBufferError::Unimplemented) => return,
+        cont => cont.unwrap(),
+    };
     for pixel in screen_contents.iter() {
         assert_eq!(*pixel, 0xFF000000);
     }


### PR DESCRIPTION
Closes #36 by adding a `fetch()` method for the `Buffer` method. Might need a rework in the face of #98 or #99.

WIP for now, with only implementations for X11 and Win32. I would appreciate guidance from the platform maintainers on how this would be implemented on other platforms.