### PR TITLE
Bump windows-sys to 0.48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ['1.60.0', stable, nightly]
+        rust_version: ['1.64.0', stable, nightly]
         platform:
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
           - { target: i686-pc-windows-msvc,     os: windows-latest,  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x11rb = { version = "0.11.0", features = ["allow-unsafe-code", "dl-libxcb", "shm
 fastrand = { version = "1.8.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.48.0"
 features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rust-windowing/softbuffer"
 keywords = ["framebuffer", "windowing"]
 categories = ["game-development", "graphics", "gui", "multimedia", "rendering"]
 exclude = ["examples"]
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen"]

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -67,7 +67,7 @@ impl Win32Impl {
             biHeight: -(height as i32),
             biPlanes: 1,
             biBitCount: 32,
-            biCompression: BI_BITFIELDS,
+            biCompression: BI_BITFIELDS as _,
             biSizeImage: 0,
             biXPelsPerMeter: 0,
             biYPelsPerMeter: 0,


### PR DESCRIPTION
Version 0.2.0 of `softbuffer` uses an outdated version of `windows-sys`. This PR bumps it to version 0.48.