### PR TITLE
Add changelog entry for 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * On MacOS, the contents scale is updated when set_buffer() is called, to adapt when the window is on a new screen.
 
+# 0.2.1
+
+* Bump `windows-sys` to 0.48
+
 # 0.2.0
 
 * Add support for Redox/Orbital.


### PR DESCRIPTION
I've published the change in #110 as version 0.2.1. This PR mirrors this release in the changelog on `master`.