### PR TITLE
Reference correct branch name in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   Check_Formatting:


### PR DESCRIPTION
CI wasn't being triggered on the default branch, because it's name is `master` not `main`.