### PR TITLE
Make documentation clearer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ impl Surface {
 ///
 /// # Data representation
 ///
-/// The format of the buffer is `BGRX8888`, which is as follows. There is one `u32` in the buffer for each pixel in
+/// The format of the buffer is `BGR0`, which is as follows. There is one `u32` in the buffer for each pixel in
 /// the area to draw. The first entry is the upper-left most pixel. The second is one to the right
 /// etc. (Row-major top to bottom left to right one `u32` per pixel). Within each `u32` the highest
 /// order 8 bits are to be set to 0. The next highest order 8 bits are the red channel, then the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ impl Surface {
 ///
 /// # Data representation
 ///
-/// The format of the buffer is as follows. There is one `u32` in the buffer for each pixel in
+/// The format of the buffer is `BGRX8888`, which is as follows. There is one `u32` in the buffer for each pixel in
 /// the area to draw. The first entry is the upper-left most pixel. The second is one to the right
 /// etc. (Row-major top to bottom left to right one `u32` per pixel). Within each `u32` the highest
 /// order 8 bits are to be set to 0. The next highest order 8 bits are the red channel, then the


### PR DESCRIPTION
From your documentation, I was under the impression that the pixel format of `softbuffer` was `XRGB`, however, as a maintainer of iced-rs/iced told me in [this](https://github.com/iced-rs/iced/discussions/1915#discussioncomment-6175061) discussion, the buffer format is actually `BGRX`. I think this documentation change would make that clearer.