### PR TITLE
Use tiny-xlib instead of x11-dl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
           - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { target: x86_64-unknown-freebsd,   os: ubuntu-latest,   }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,20 +20,21 @@ harness = false
 default = ["x11", "wayland", "wayland-dlopen"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
-x11 = ["bytemuck", "nix", "x11rb", "x11-dl"]
+x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]
 
 [dependencies]
 log = "0.4.17"
 raw-window-handle = "0.5.0"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
+as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
 memmap2 = { version = "0.6.1", optional = true }
 nix = { version = "0.26.1", optional = true }
+tiny-xlib = { version = "0.2.1", optional = true }
 wayland-backend = { version = "0.1.0", features = ["client_system"], optional = true }
 wayland-client = { version = "0.30.0", optional = true }
 wayland-sys = "0.30.0"
-x11-dl = { version  = "2.19.1", optional = true }
 x11rb = { version = "0.12.0", features = ["allow-unsafe-code", "dl-libxcb", "shm"], optional = true }
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox", target_os = "linux", target_os = "freebsd"))))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "buffer_mut"
 harness = false
 
 [features]
-default = ["x11", "wayland", "wayland-dlopen"]
+default = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = ["x11", "wayland", "wayland-dlopen"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]
+x11-dlopen = ["tiny-xlib/dlopen", "x11rb/dl-libxcb"]
 
 [dependencies]
 log = "0.4.17"
@@ -35,7 +36,7 @@ tiny-xlib = { version = "0.2.1", optional = true }
 wayland-backend = { version = "0.1.0", features = ["client_system"], optional = true }
 wayland-client = { version = "0.30.0", optional = true }
 wayland-sys = "0.30.0"
-x11rb = { version = "0.12.0", features = ["allow-unsafe-code", "dl-libxcb", "shm"], optional = true }
+x11rb = { version = "0.12.0", features = ["allow-unsafe-code", "shm"], optional = true }
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox", target_os = "linux", target_os = "freebsd"))))'.dependencies]
 fastrand = { version = "1.8.0", optional = true }


### PR DESCRIPTION
As of now, `x11-dl` takes up a significant part of our executable.

![image](https://github.com/rust-windowing/softbuffer/assets/19805233/6419b087-4356-4328-b573-95355cd9c767)

In order to avoid this bloat, especially since we only really use one function from Xlib, I've created the [`tiny-xlib`](https://crates.io/crates/tiny-xlib) crate to act as a small interface over Xlib and Xlib-Xcb. This PR replaces the `x11-dl` crate with `tiny-xlib`.