### PR TITLE
examples/winit: Implement proper `resumed()` semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,21 +79,27 @@ mod winit_app;
 fn main() {
     let event_loop = EventLoop::new().unwrap();
 
-    let mut app = winit_app::WinitAppBuilder::with_init(|elwt| {
-        let window = {
-            let window = elwt.create_window(Window::default_attributes());
-            Rc::new(window.unwrap())
-        };
-        let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+    let mut app = winit_app::WinitAppBuilder::with_init(
+        |elwt| {
+            let window = {
+                let window = elwt.create_window(Window::default_attributes());
+                Rc::new(window.unwrap())
+            };
+            let context = softbuffer::Context::new(window.clone()).unwrap();
 
-        (window, surface)
-    }).with_event_handler(|state, event, elwt| {
-        let (window, surface) = state;
+            (window, context)
+        },
+        |_elwt, (window, context)| softbuffer::Surface::new(context, window.clone()).unwrap(),
+    )
+    .with_event_handler(|(window, _context), surface, event, elwt| {
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {
             Event::WindowEvent { window_id, event: WindowEvent::RedrawRequested } if window_id == window.id() => {
+                let Some(surface) = surface else {
+                    eprintln!("RedrawRequested fired before Resumed or after Suspended");
+                    return;
+                };
                 let (width, height) = {
                     let size = window.inner_size();
                     (size.width, size.height)


### PR DESCRIPTION
On Android the backing buffer (`NativeWindow`) disappears when the application is not focussed and/or the screen is locked.  Winit handles this by requiring apps to create their `raw_window_handle()` consumers _after_ `Event::Resumed` and to clean it up _before_ returning from `Event::Suspended`.  For consistency Winit also sends `Resumed` on all other platforms during init.

---

Draft until this is transplanted to all the other examples, even though that doesn't magically make them run on Android yet.
