### PR TITLE
Reintroduce Error trait impl for SoftBufferError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,8 @@ impl fmt::Display for SoftBufferError {
     }
 }
 
+impl std::error::Error for SoftBufferError {}
+
 /// Convenient wrapper to cast errors into SoftBufferError.
 pub(crate) trait SwResultExt<T> {
     fn swbuf_err(self, msg: impl Into<String>) -> Result<T, SoftBufferError>;


### PR DESCRIPTION
This trait implementation was removed in #116. It's not mentioned as a breaking change in [the changelog](https://github.com/rust-windowing/softbuffer/blob/master/CHANGELOG.md#030), so I'm guessing this was unintentional. This PR reintroduces the implementation.