### PR TITLE
Add a DRM/KMS backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 # Apple platforms
 /src/cg.rs          @madsmtm
 
+# DRM/KMS (no maintainer)
+/src/kms.rs
+
 # Redox
 /src/orbital.rs     @jackpot51
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "kms" }
           - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { target: x86_64-unknown-freebsd,   os: ubuntu-latest,   }
-          - { target: x86_64-unknown-netbsd,    os: ubuntu-latest, options: --no-defaut-features, features: "x11,x11-dlopen,wayland,wayland-dlopen"  }
+          - { target: x86_64-unknown-netbsd,    os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen,wayland,wayland-dlopen"  }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "kms" }
           - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { target: x86_64-unknown-freebsd,   os: ubuntu-latest,   }
-          - { target: x86_64-unknown-netbsd,    os: ubuntu-latest,   }
+          - { target: x86_64-unknown-netbsd,    os: ubuntu-latest, options: --no-defaut-features, features: "x11,x11-dlopen,wayland,wayland-dlopen"  }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "kms" }
           - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { target: x86_64-unknown-freebsd,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-netbsd,    os: ubuntu-latest,   }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ redox_syscall = "0.3"
 cfg_aliases = "0.1.1"
 
 [dev-dependencies]
+colorous = "1.0.12"
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 instant = "0.1.12"
 winit = "0.28.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ wasm-bindgen-test = "0.3"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dev-dependencies]
 rustix = { version = "0.38.8", features = ["event"] }
-udev = "0.7.0"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 
 [features]
 default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
-kms = ["bytemuck", "drm"]
+kms = ["bytemuck", "drm", "drm-sys"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]
@@ -32,6 +32,7 @@ raw-window-handle = "0.5.0"
 as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
 drm = { version = "0.9.0", default-features = false, optional = true }
+drm-sys = { version = "0.4.0", default-features = false, optional = true }
 memmap2 = { version = "0.7.1", optional = true }
 nix = { version = "0.26.1", optional = true }
 tiny-xlib = { version = "0.2.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ rayon = "1.5.1"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
+[target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dev-dependencies]
+rustix = { version = "0.38.8", features = ["event"] }
+udev = "0.7.0"
+
 [workspace]
 members = [
     "run-wasm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 
 [features]
 default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
-kms = ["drm"]
+kms = ["bytemuck", "drm"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ name = "buffer_mut"
 harness = false
 
 [features]
-default = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"]
+default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
+kms = ["drm"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]
@@ -30,6 +31,7 @@ raw-window-handle = "0.5.0"
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
 as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
+drm = { version = "0.9.0", default-features = false, optional = true }
 memmap2 = { version = "0.7.1", optional = true }
 nix = { version = "0.26.1", optional = true }
 tiny-xlib = { version = "0.2.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 
 [features]
 default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
-kms = ["bytemuck", "drm", "drm-sys"]
+kms = ["bytemuck", "drm", "drm-sys", "nix"]
 wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         free_unix: { all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))) },
+        kms_platform: { all(feature = "kms", free_unix, not(target_arch = "wasm32")) },
         x11_platform: { all(feature = "x11", free_unix, not(target_arch = "wasm32")) },
         wayland_platform: { all(feature = "wayland", free_unix, not(target_arch = "wasm32")) },
     }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -1,0 +1,172 @@
+//! Example of using softbuffer with drm-rs.
+
+#[cfg(kms_platform)]
+mod imple {
+    use drm::control::{connector, Device as CtrlDevice, ModeTypeFlags, PlaneType};
+    use drm::Device;
+
+    use raw_window_handle::{DrmDisplayHandle, DrmWindowHandle};
+    use softbuffer::{Context, Surface};
+
+    use std::num::NonZeroU32;
+    use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
+    use std::time::{Duration, Instant};
+
+    pub(super) fn entry() -> Result<(), Box<dyn std::error::Error>> {
+        // Open a new device.
+        let device = Card::open()?;
+
+        // Create the softbuffer context.
+        let context = unsafe {
+            Context::from_raw({
+                let mut handle = DrmDisplayHandle::empty();
+                handle.fd = device.as_fd().as_raw_fd();
+                handle.into()
+            })
+        }?;
+
+        // Get the DRM handles.
+        let handles = device.resource_handles()?;
+
+        // Get the list of connectors and CRTCs.
+        let connectors = handles
+            .connectors()
+            .iter()
+            .map(|&con| device.get_connector(con, true))
+            .collect::<Result<Vec<_>, _>>()?;
+        let crtcs = handles
+            .crtcs()
+            .iter()
+            .map(|&crtc| device.get_crtc(crtc))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Find a connected crtc.
+        let con = connectors
+            .iter()
+            .find(|con| con.state() == connector::State::Connected)
+            .ok_or("No connected connectors")?;
+
+        // Get the first CRTC.
+        let crtc = crtcs.first().ok_or("No CRTCs")?;
+
+        // Find a mode to use.
+        let mode = con
+            .modes()
+            .iter()
+            .find(|mode| mode.mode_type().contains(ModeTypeFlags::PREFERRED))
+            .or_else(|| con.modes().first())
+            .ok_or("No modes")?;
+
+        // Look for a primary plane compatible with our CRTC.
+        let planes = device.plane_handles()?;
+        let planes = planes
+            .iter()
+            .filter(|&&plane| {
+                device.get_plane(plane).map_or(false, |plane| {
+                    let crtcs = handles.filter_crtcs(plane.possible_crtcs());
+                    crtcs.contains(&crtc.handle())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Find the first primary plane or take the first one period.
+        let plane = planes
+            .iter()
+            .find(|&&&plane| {
+                if let Ok(props) = device.get_properties(plane) {
+                    let (ids, vals) = props.as_props_and_values();
+                    for (&id, &val) in ids.iter().zip(vals.iter()) {
+                        if let Ok(info) = device.get_property(id) {
+                            if info.name().to_str().map_or(false, |x| x == "type") {
+                                return val == PlaneType::Primary as u32 as u64;
+                            }
+                        }
+                    }
+                }
+
+                false
+            })
+            .or(planes.first())
+            .ok_or("No planes")?;
+
+        // Create the surface on top of this plane.
+        // Note: This requires root on DRM/KMS.
+        let mut surface = unsafe {
+            Surface::from_raw(&context, {
+                let mut handle = DrmWindowHandle::empty();
+                handle.plane = (**plane).into();
+                handle.into()
+            })
+        }?;
+
+        // Resize the surface.
+        let (width, height) = mode.size();
+        surface.resize(
+            NonZeroU32::new(width as u32).unwrap(),
+            NonZeroU32::new(height as u32).unwrap(),
+        )?;
+
+        // Start drawing to it.
+        let start = Instant::now();
+        let mut tick = 0;
+        while Instant::now().duration_since(start) < Duration::from_secs(2) {
+            tick += 1;
+            println!("Drawing tick {tick}");
+
+            // Start drawing.
+            let mut buffer = surface.buffer_mut()?;
+            draw_to_buffer(&mut buffer, tick);
+            buffer.present()?;
+
+            // Sleep for a little.
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        Ok(())
+    }
+
+    fn draw_to_buffer(buf: &mut [u32], tick: usize) {
+        let scale = colorous::VIRIDIS;
+        let mut i = (tick as f64) / 10.0;
+        while i > 1.0 {
+            i -= 1.0;
+        }
+
+        let color = scale.eval_continuous(i);
+        let pixel = (color.r as u32) << 16 | (color.g as u32) << 8 | (color.b as u32);
+        buf.fill(pixel);
+    }
+
+    struct Card(std::fs::File);
+
+    impl Card {
+        fn open() -> Result<Card, Box<dyn std::error::Error>> {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/dri/card0")?;
+            Ok(Card(file))
+        }
+    }
+
+    impl AsFd for Card {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            self.0.as_fd()
+        }
+    }
+
+    impl Device for Card {}
+    impl CtrlDevice for Card {}
+}
+
+#[cfg(not(kms_platform))]
+mod imple {
+    pub(super) fn entry() -> Result<(), Box<dyn std::error::Error>> {
+        eprintln!("This example requires the `kms` feature.");
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    imple::entry()
+}

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -174,7 +174,7 @@ mod imple {
                     Ok(handles) => handles,
                     Err(_) => continue,
                 };
-                
+
                 if !handles.connectors.is_empty() {
                     return Ok(device);
                 }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -2,7 +2,7 @@
 
 #[cfg(kms_platform)]
 mod imple {
-    use drm::control::{connector, Device as CtrlDevice, ModeTypeFlags, PlaneType};
+    use drm::control::{connector, Device as CtrlDevice, Event, ModeTypeFlags, PlaneType};
     use drm::Device;
 
     use raw_window_handle::{DrmDisplayHandle, DrmWindowHandle};
@@ -118,16 +118,30 @@ mod imple {
             draw_to_buffer(&mut buffer, tick);
             buffer.present()?;
 
-            // Sleep for a little.
-            std::thread::sleep(Duration::from_millis(5));
+            // Wait for the page flip to happen.
+            let events = device.receive_events()?;
+            println!("Got some events...");
+            for event in events {
+                match event {
+                    Event::PageFlip(_) => {
+                        println!("Page flip event.");
+                    }
+                    Event::Vblank(_) => {
+                        println!("Vblank event.");
+                    }
+                    _ => {
+                        println!("Unknown event.");
+                    }
+                }
+            }
         }
 
         Ok(())
     }
 
     fn draw_to_buffer(buf: &mut [u32], tick: usize) {
-        let scale = colorous::VIRIDIS;
-        let mut i = (tick as f64) / 10.0;
+        let scale = colorous::SINEBOW;
+        let mut i = (tick as f64) / 20.0;
         while i > 1.0 {
             i -= 1.0;
         }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -175,7 +175,12 @@ mod imple {
                     Err(_) => continue,
                 };
 
-                if !handles.connectors.is_empty() {
+                if handles
+                    .connectors
+                    .iter()
+                    .filter_map(|c| device.get_connector(*c, false).ok())
+                    .any(|c| c.state() == connector::State::Connected)
+                {
                     return Ok(device);
                 }
             }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -1,0 +1,286 @@
+//! Backend for DRM/KMS for raw rendering directly to the screen.
+//!
+//! This strategy uses dumb buffers for rendering.
+
+use drm::buffer::{Buffer, DrmFourcc};
+use drm::control::dumbbuffer::{DumbBuffer, DumbMapping};
+use drm::control::{connector, crtc, framebuffer, plane, Device as CtrlDevice};
+use drm::Device;
+
+use raw_window_handle::{DrmDisplayHandle, DrmWindowHandle};
+
+use std::num::NonZeroU32;
+use std::os::unix::io::{AsFd, BorrowedFd};
+use std::rc::Rc;
+
+use crate::error::{SoftBufferError, SwResultExt};
+
+#[derive(Debug)]
+pub(crate) struct KmsDisplayImpl {
+    /// The underlying raw device file descriptor.
+    ///
+    /// Once rwh v0.6 support is merged, this an be made safe. Until then,
+    /// we use this hacky workaround, since this FD's validity is guaranteed by
+    /// the unsafe constructor.
+    fd: BorrowedFd<'static>,
+}
+
+impl AsFd for KmsDisplayImpl {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd
+    }
+}
+
+impl Device for KmsDisplayImpl {}
+impl CtrlDevice for KmsDisplayImpl {}
+
+impl KmsDisplayImpl {
+    /// SAFETY: The underlying fd must not outlive the display.
+    pub(crate) unsafe fn new(handle: DrmDisplayHandle) -> Result<KmsDisplayImpl, SoftBufferError> {
+        let fd = handle.fd;
+        if fd == -1 {
+            return Err(SoftBufferError::IncompleteDisplayHandle);
+        }
+
+        // SAFETY: Invariants guaranteed by the user.
+        let fd = unsafe { BorrowedFd::borrow_raw(fd) };
+
+        Ok(KmsDisplayImpl { fd })
+    }
+}
+
+/// All the necessary types for the Drm/Kms backend.
+#[derive(Debug)]
+pub(crate) struct KmsImpl {
+    /// The display implementation.
+    display: Rc<KmsDisplayImpl>,
+
+    /// The connector to use.
+    connector: connector::Handle,
+
+    /// The CRTC to render to.
+    crtc: crtc::Info,
+
+    /// The dumb buffer we're using as a buffer.
+    buffer: Option<BufferSet>,
+}
+
+/// The buffer implementation.
+pub(crate) struct BufferImpl<'a> {
+    /// The mapping of the dump buffer.
+    mapping: DumbMapping<'a>,
+
+    /// The framebuffer.
+    fb: framebuffer::Handle,
+
+    /// The connector.
+    connector: connector::Handle,
+
+    /// The CRTC info.
+    crtc_info: &'a crtc::Info,
+
+    /// The display implementation.
+    display: &'a KmsDisplayImpl,
+
+    /// The zero buffer.
+    zeroes: &'a [u32],
+}
+
+/// The combined frame buffer and dumb buffer.
+#[derive(Debug)]
+struct BufferSet {
+    /// The frame buffer.
+    fb: framebuffer::Handle,
+
+    /// The dumb buffer.
+    db: DumbBuffer,
+
+    /// Equivalent mapping for reading.
+    zeroes: Box<[u32]>,
+}
+
+impl KmsImpl {
+    /// Create a new KMS backend.
+    ///
+    /// # Safety
+    ///
+    /// The plane must be valid for the lifetime of the backend.
+    pub(crate) unsafe fn new(
+        window_handle: DrmWindowHandle,
+        display: Rc<KmsDisplayImpl>,
+    ) -> Result<Self, SoftBufferError> {
+        log::trace!("new: window_handle={:X}", window_handle.plane);
+
+        // Make sure that the window handle is valid.
+        let plane_handle = match NonZeroU32::new(window_handle.plane) {
+            Some(handle) => plane::Handle::from(handle),
+            None => return Err(SoftBufferError::IncompleteWindowHandle),
+        };
+
+        let plane_info = display
+            .get_plane(plane_handle)
+            .swbuf_err("failed to get plane info")?;
+        let handles = display
+            .resource_handles()
+            .swbuf_err("failed to get resource handles")?;
+
+        // Use either the attached CRTC or the primary CRTC.
+        let crtc = match plane_info.crtc() {
+            Some(crtc) => crtc,
+            None => {
+                log::warn!("no CRTC attached to plane, falling back to primary CRTC");
+                handles
+                    .filter_crtcs(plane_info.possible_crtcs())
+                    .first()
+                    .copied()
+                    .swbuf_err("failed to find a primary CRTC")?
+            }
+        };
+
+        // Use a preferred connector or just select the first one.
+        let connector = handles
+            .connectors
+            .iter()
+            .flat_map(|handle| display.get_connector(*handle, false))
+            .find_map(|conn| {
+                if conn.state() == connector::State::Connected {
+                    Some(conn.handle())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| handles.connectors.first().copied())
+            .swbuf_err("failed to find a valid connector")?;
+
+        Ok(Self {
+            crtc: display
+                .get_crtc(crtc)
+                .swbuf_err("failed to get CRTC info")?,
+            connector,
+            display,
+            buffer: None,
+        })
+    }
+
+    /// Resize the internal buffer to the given size.
+    pub(crate) fn resize(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> Result<(), SoftBufferError> {
+        // Don't resize if we don't have to.
+        if let Some(buffer) = &self.buffer {
+            let (buffer_width, buffer_height) = buffer.size();
+            if buffer_width == width && buffer_height == height {
+                return Ok(());
+            }
+        }
+
+        // Create a new buffer.
+        let buffer = BufferSet::new(&self.display, width, height)?;
+        self.buffer = Some(buffer);
+
+        Ok(())
+    }
+
+    /// Fetch the buffer from the window.
+    pub(crate) fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
+        // TODO: Implement this!
+        Err(SoftBufferError::Unimplemented)
+    }
+
+    /// Get a mutable reference to the buffer.
+    pub(crate) fn buffer_mut(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+        // Map the dumb buffer.
+        let set = self
+            .buffer
+            .as_mut()
+            .expect("Must set size of surface before calling `buffer_mut()`");
+        let mapping = self
+            .display
+            .map_dumb_buffer(&mut set.db)
+            .swbuf_err("failed to map dumb buffer")?;
+
+        Ok(BufferImpl {
+            mapping,
+            fb: set.fb,
+            connector: self.connector,
+            crtc_info: &self.crtc,
+            display: &self.display,
+            zeroes: &set.zeroes,
+        })
+    }
+}
+
+impl BufferImpl<'_> {
+    #[inline]
+    pub fn pixels(&self) -> &[u32] {
+        // drm-rs doesn't let us have the immutable reference... so just use a bunch of zeroes.
+        // TODO: There has to be a better way of doing this!
+        self.zeroes
+    }
+
+    #[inline]
+    pub fn pixels_mut(&mut self) -> &mut [u32] {
+        bytemuck::cast_slice_mut(self.mapping.as_mut())
+    }
+
+    #[inline]
+    pub fn age(&self) -> u8 {
+        todo!()
+    }
+
+    #[inline]
+    pub fn present_with_damage(self, _damage: &[crate::Rect]) -> Result<(), SoftBufferError> {
+        // TODO: Is there a way of doing this?
+        self.present()
+    }
+
+    #[inline]
+    pub fn present(self) -> Result<(), SoftBufferError> {
+        // Set the CRTC mode.
+        // TODO: This requires root access, find a way that doesn't!
+        self.display
+            .set_crtc(
+                self.crtc_info.handle(),
+                Some(self.fb),
+                (0, 0),
+                &[self.connector],
+                self.crtc_info.mode(),
+            )
+            .swbuf_err("failed to set CRTC")?;
+
+        Ok(())
+    }
+}
+
+impl BufferSet {
+    /// Create a new buffer set.
+    pub(crate) fn new(
+        display: &KmsDisplayImpl,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> Result<Self, SoftBufferError> {
+        let db = display
+            .create_dumb_buffer((width.get(), height.get()), DrmFourcc::Argb8888, 32)
+            .swbuf_err("failed to create dumb buffer")?;
+        let fb = display
+            .add_framebuffer(&db, 32, 32)
+            .swbuf_err("failed to add framebuffer")?;
+
+        Ok(BufferSet {
+            fb,
+            db,
+            zeroes: vec![0; width.get() as usize * height.get() as usize].into_boxed_slice(),
+        })
+    }
+
+    /// Get the size of this buffer.
+    pub(crate) fn size(&self) -> (NonZeroU32, NonZeroU32) {
+        let (width, height) = self.db.size();
+
+        NonZeroU32::new(width)
+            .and_then(|width| NonZeroU32::new(height).map(|height| (width, height)))
+            .expect("buffer size is zero")
+    }
+}

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -222,6 +222,21 @@ impl KmsImpl {
     }
 }
 
+impl Drop for KmsImpl {
+    fn drop(&mut self) {
+        // Map the CRTC to the information that was there before.
+        self.display
+            .set_crtc(
+                self.crtc.handle(),
+                self.crtc.framebuffer(),
+                self.crtc.position(),
+                &[self.connector],
+                self.crtc.mode(),
+            )
+            .ok();
+    }
+}
+
 impl BufferImpl<'_> {
     #[inline]
     pub fn pixels(&self) -> &[u32] {
@@ -290,10 +305,10 @@ impl BufferSet {
         height: NonZeroU32,
     ) -> Result<Self, SoftBufferError> {
         let db = display
-            .create_dumb_buffer((width.get(), height.get()), DrmFourcc::Argb8888, 32)
+            .create_dumb_buffer((width.get(), height.get()), DrmFourcc::Xrgb8888, 32)
             .swbuf_err("failed to create dumb buffer")?;
         let fb = display
-            .add_framebuffer(&db, 32, 32)
+            .add_framebuffer(&db, 24, 32)
             .swbuf_err("failed to add framebuffer")?;
 
         Ok(BufferSet {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,12 @@ impl Surface {
     /// Return a [`Buffer`] that the next frame should be rendered into. The size must
     /// be set with [`Surface::resize`] first. The initial contents of the buffer may be zeroed, or
     /// may contain a previous frame. Call [`Buffer::age`] to determine this.
+    /// 
+    /// ## Platform Dependent Behavior
+    /// 
+    /// - On DRM/KMS, there is no reliable and sound way to wait for the page flip to happen from within
+    ///   `softbuffer`. Therefore it is the responsibility of the user to wait for the page flip before
+    ///   sending another frame.
     pub fn buffer_mut(&mut self) -> Result<Buffer, SoftBufferError> {
         Ok(Buffer {
             buffer_impl: self.surface_impl.buffer_mut()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod util;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use std::ops;
-#[cfg(any(wayland_platform, x11_platform))]
+#[cfg(any(wayland_platform, x11_platform, kms_platform))]
 use std::rc::Rc;
 
 pub use error::SoftBufferError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ macro_rules! make_dispatch {
             }
         }
 
+        #[allow(clippy::large_enum_variant)] // it's boxed anyways
         enum SurfaceDispatch {
             $(
                 $(#[$attr])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,9 +376,9 @@ impl Surface {
     /// Return a [`Buffer`] that the next frame should be rendered into. The size must
     /// be set with [`Surface::resize`] first. The initial contents of the buffer may be zeroed, or
     /// may contain a previous frame. Call [`Buffer::age`] to determine this.
-    /// 
+    ///
     /// ## Platform Dependent Behavior
-    /// 
+    ///
     /// - On DRM/KMS, there is no reliable and sound way to wait for the page flip to happen from within
     ///   `softbuffer`. Therefore it is the responsibility of the user to wait for the page flip before
     ///   sending another frame.


### PR DESCRIPTION
This adds a DRM/KMS based backend to the system, as per #42. This system finds a CRTC and a connector, then uses that to create a frame buffer and a DUMB buffer that it can render to.

~~All of this is untested, hence the draft status.~~

I'm not going to be the maintainer for this backend, as I'm self-imposing a limit of two backends on myself. If anyone else with DRM/KMS experience or a motivating use case wants to maintain this backend, let me know. Otherwise I've marked it as unmaintained.

Closes #42