### PR TITLE
orbital: Use `syscall::MAP_SHARED` for mapping

### DIFF
--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -22,7 +22,7 @@ impl OrbitalMap {
                 &syscall::Map {
                     offset: 0,
                     size,
-                    flags: syscall::PROT_READ | syscall::PROT_WRITE,
+                    flags: syscall::PROT_READ | syscall::PROT_WRITE | syscall::MAP_SHARED,
                     address: 0,
                 },
             )?


### PR DESCRIPTION
This seems to be required to work correctly since https://gitlab.redox-os.org/redox-os/orbital/-/merge_requests/51.

Orbclient had a similar change: https://gitlab.redox-os.org/redox-os/orbclient/-/commit/9097e71c9a61f0f654113881a485e16ce3854c62.