### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# UNRELEASED
+# 0.3.1
 
 * On X11, fix the length of the returned buffer when using the wire-transferred buffer.
 * On Web, fix incorrect starting coordinates when handling buffer damage.
+* Or Redox, use `MAP_SHARED`; fixing behavior with latest Orbital.
+* Error instead of segfault on macOS if size isn't set.
+* Add `OffscreenCanvas` support in web backend.
+* Add DRM/KMS backend, for running on tty without X/Wayland.
+* Make `fetch` error on Windows, where it wasn't working correctly.
+* Implement `Error` trait for `SoftBufferError`.
+* Dependency updates.
 
 # 0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"


### PR DESCRIPTION
Softbuffer is broken on recent builds of Redox without the fix here, so it's helpful to have a new release that fixes it. We seem to have accumulated a few non-breaking fixes, so it seems like a good enough time to do a release anyway.

Disabling `fetch` on Windows could be considered breaking, but it doesn't change the API, was broken anyway, and is likely unused. So I don't think that's an issue.