### PR TITLE
Update macOS dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundat
 [target.'cfg(target_os = "macos")'.dependencies]
 bytemuck = { version = "1.12.3", features = ["extern_crate_alloc"] }
 cocoa = "0.25.0"
-core-graphics = "0.22.3"
-foreign-types = "0.3.0"
+core-graphics = "0.23.1"
+foreign-types = "0.5.0"
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Updates ` foreign-types` and `core-graphics`, these two updates are intertwined.

Fixes https://github.com/rust-windowing/softbuffer/pull/94 and fixes https://github.com/rust-windowing/softbuffer/pull/133.