### PR TITLE
Fix length of returned buffer on x11 when using the wire-transferred buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* On X11, fix the length of the returned buffer when using the wire-transferred buffer.
+
 # 0.3.0
 
 * On MacOS, the contents scale is updated when set_buffer() is called, to adapt when the window is on a new screen (#68).

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -486,7 +486,7 @@ impl Buffer {
         match self {
             Buffer::Shm(ref mut shm) => shm.alloc_segment(conn, total_len(width, height)),
             Buffer::Wire(wire) => {
-                wire.resize(total_len(width, height), 0);
+                wire.resize(total_len(width, height) / 4, 0);
                 Ok(())
             }
         }


### PR DESCRIPTION
total_len() computes the number of bytes, while the wire Vec holds u32.