### PR TITLE
fix(web): optimize and fix present_with_damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 * On X11, fix the length of the returned buffer when using the wire-transferred buffer.
+* On Web, fix incorrect starting coordinates when handling buffer damage.
 
 # 0.3.0
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,10 @@
 // Not needed on all platforms
 #![allow(dead_code)]
 
+use std::cmp;
+use std::num::NonZeroU32;
+
+use crate::Rect;
 use crate::SoftBufferError;
 
 /// Takes a mutable reference to a container and a function deriving a
@@ -42,6 +46,41 @@ impl<'a, T: 'static + ?Sized, U: 'static + ?Sized> BorrowStack<'a, T, U> {
         // mutable reference is unique.
         unsafe { &mut *self.container }
     }
+}
+
+/// Calculates the smallest `Rect` necessary to represent all damaged `Rect`s.
+pub(crate) fn union_damage(damage: &[Rect]) -> Option<Rect> {
+    struct Region {
+        left: u32,
+        top: u32,
+        bottom: u32,
+        right: u32,
+    }
+
+    let region = damage
+        .iter()
+        .map(|rect| Region {
+            left: rect.x,
+            top: rect.y,
+            right: rect.x + rect.width.get(),
+            bottom: rect.y + rect.height.get(),
+        })
+        .reduce(|mut prev, next| {
+            prev.left = cmp::min(prev.left, next.left);
+            prev.top = cmp::min(prev.top, next.top);
+            prev.right = cmp::max(prev.right, next.right);
+            prev.bottom = cmp::max(prev.bottom, next.bottom);
+            prev
+        })?;
+
+    Some(Rect {
+        x: region.left,
+        y: region.top,
+        width: NonZeroU32::new(region.right - region.left)
+            .expect("`right` must always be bigger then `left`"),
+        height: NonZeroU32::new(region.bottom - region.top)
+            .expect("`bottom` must always be bigger then `top`"),
+    })
 }
 
 #[cfg(test)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -146,7 +146,12 @@ impl WebImpl {
 
         let mut damage_iter = damage.iter();
 
-        let first_rect = damage_iter.next().expect("at least one damage rectangle");
+        let first_rect = if let Some(rect) = damage_iter.next() {
+            rect
+        } else {
+            // If there is no damage, there is nothing to do
+            return Ok(());
+        };
 
         struct UnionRegion {
             top: u32,

--- a/src/web.rs
+++ b/src/web.rs
@@ -322,7 +322,7 @@ impl Canvas {
 
     // NOTE: suppress the lint because we mirror `CanvasRenderingContext2D`’s `putImageData`, and
     // this is just an internal API used by this module only, so it’s not too relevant.
-    #[allow(clippy::too-many-arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn put_image_data(
         &self,
         imagedata: &ImageData,
@@ -330,17 +330,17 @@ impl Canvas {
         dy: f64,
         dirty_x: f64,
         dirty_y: f64,
-        widht: f64,
+        width: f64,
         height: f64,
     ) -> Result<(), JsValue> {
         match self {
             Self::Canvas { ctx, .. } => ctx
                 .put_image_data_with_dirty_x_and_dirty_y_and_dirty_width_and_dirty_height(
-                    imagedata, dx, dy, dirty_x, dirty_y, widht, height,
+                    imagedata, dx, dy, dirty_x, dirty_y, width, height,
                 ),
             Self::OffscreenCanvas { ctx, .. } => ctx
                 .put_image_data_with_dirty_x_and_dirty_y_and_dirty_width_and_dirty_height(
-                    imagedata, dx, dy, dirty_x, dirty_y, widht, height,
+                    imagedata, dx, dy, dirty_x, dirty_y, width, height,
                 ),
         }
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -320,6 +320,9 @@ impl Canvas {
         }
     }
 
+    // NOTE: suppress the lint because we mirror `CanvasRenderingContext2D`’s `putImageData`, and
+    // this is just an internal API used by this module only, so it’s not too relevant.
+    #[allow(clippy::too-many-arguments)]
     fn put_image_data(
         &self,
         imagedata: &ImageData,


### PR DESCRIPTION
This patch fixes the `present_with_damage` implementation for the web backend. `CanvasRenderingContext2D`’s `putImageData` was used incorrectly.

As per [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData):

> imageData
>
>   An ImageData object containing the array of pixel values.
>
> dx
>
>   Horizontal position (x coordinate) at which to place the image data
>   in the destination canvas.
>
> dy
>
>   Vertical position (y coordinate) at which to place the image data
>   in the destination canvas.
>
> dirtyX
>
>   Horizontal position (x coordinate) of the top-left corner from which
>   the image data will be extracted. Defaults to 0.
>
> dirtyY
>
>   Vertical position (y coordinate) of the top-left corner from which
>   the image data will be extracted. Defaults to 0.

As such, `dx` is different from `dirtyX` and `dy` is different from `dirtyY`.

When the actual `ImageData` is as big as the canvas itself, `dx` and `dy` should always be `0.0` and `0.0`, and only `dirtyX` and `dirtyY` are actually representing the top-left coordinates for the dirty region. The dirty region is relative to the image data.

This patch also optimizes the BGRX to RGBA conversion by only creating a bitmap for the smallest region enclosing all the damaged regions. This does not affect the behavior of `present`.