### PR TITLE
Temporarily disable Windows GNU CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
         platform:
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
           - { target: i686-pc-windows-msvc,     os: windows-latest,  }
-          - { target: x86_64-pc-windows-gnu,    os: windows-latest, host: -x86_64-pc-windows-gnu }
-          - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
+          # TODO: wait for https://github.com/microsoft/windows-rs/issues/2614#issuecomment-1684152597
+          #       to be resolved before re-enabling these
+          # - { target: x86_64-pc-windows-gnu,    os: windows-latest, host: -x86_64-pc-windows-gnu }
+          # - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen" }


### PR DESCRIPTION
They are currently failing due to what we believe is a bug in the Windows bindings for Rust. For now, disable these until this bug is resolved.

Closes #142