### PR TITLE
doc: present_with_damage is supported on web platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,7 @@ impl<'a> Buffer<'a> {
     /// - Wayland
     /// - X, when XShm is available
     /// - Win32
+    /// - Web
     ///
     /// Otherwise this is equivalent to [`Self::present`].
     pub fn present_with_damage(self, damage: &[Rect]) -> Result<(), SoftBufferError> {


### PR DESCRIPTION
Updates the doc of `present_with_damage` to reflect that it is supported for the web platform.