### PR TITLE
Use `rustix`/`libc` instead of `nix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ harness = false
 
 [features]
 default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
-kms = ["bytemuck", "drm", "nix"]
-wayland = ["wayland-backend", "wayland-client", "memmap2", "nix", "fastrand"]
+kms = ["bytemuck", "drm", "libc", "rustix"]
+wayland = ["wayland-backend", "wayland-client", "memmap2", "rustix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
-x11 = ["as-raw-xcb-connection", "bytemuck", "nix", "tiny-xlib", "x11rb"]
+x11 = ["as-raw-xcb-connection", "bytemuck", "libc", "rustix", "tiny-xlib", "x11rb"]
 x11-dlopen = ["tiny-xlib/dlopen", "x11rb/dl-libxcb"]
 
 [dependencies]
@@ -33,7 +33,8 @@ as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
 drm = { version = "0.10.0", default-features = false, optional = true }
 memmap2 = { version = "0.9.0", optional = true }
-nix = { version = "0.27.0", features = ["fs", "mman"], optional = true }
+libc = { version = "0.2.149", optional = true }
+rustix = { version = "0.38.19", features = ["fs", "mm", "shm"], optional = true }
 tiny-xlib = { version = "0.2.1", optional = true }
 wayland-backend = { version = "0.3.0", features = ["client_system"], optional = true }
 wayland-client = { version = "0.31.0", optional = true }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -332,10 +332,8 @@ impl BufferImpl<'_> {
         // this is going to fail. Low hanging fruit PR: add a flag that's set to false if this
         // returns `ENOSYS` and check that before allocating the above and running this.
         match self.display.dirty_framebuffer(self.front_fb, &rectangles) {
-            Ok(())
-            | Err(drm::SystemError::Unknown {
-                errno: nix::errno::Errno::ENOSYS,
-            }) => {}
+            Ok(()) => {}
+            Err(drm::SystemError::Unknown { errno }) if errno as i32 == libc::ENOSYS => {}
             Err(e) => {
                 return Err(SoftBufferError::PlatformError(
                     Some("failed to dirty framebuffer".into()),

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -7,7 +7,7 @@
 
 use crate::error::SwResultExt;
 use crate::{Rect, SoftBufferError};
-use nix::libc::{shmat, shmctl, shmdt, shmget, IPC_PRIVATE, IPC_RMID};
+use libc::{shmat, shmctl, shmdt, shmget, IPC_PRIVATE, IPC_RMID};
 use raw_window_handle::{XcbDisplayHandle, XcbWindowHandle, XlibDisplayHandle, XlibWindowHandle};
 use std::ptr::{null_mut, NonNull};
 use std::{


### PR DESCRIPTION
Partly addresses https://github.com/rust-windowing/softbuffer/issues/147, though it would still be desirable to have a good safe API for SYSV shm in Rustix. But using `libc` directly for now is no worse than using the `nix::libc` re-export, so we don't lose anything.