### PR TITLE
Fix missing paragraph break in the docs for `Buffer`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
 /// - X, when XShm is available
 /// - Win32
 /// - Orbital, when buffer size matches window size
+///
 /// Currently [`Buffer::present`] must block copying image data on:
 /// - Web
 /// - macOS


### PR DESCRIPTION
Right now the bit of the docs for `Buffer` discussing which platforms require copying looks like this:

![Screenshot 2023-10-29 at 5 46 01 pm](https://github.com/rust-windowing/softbuffer/assets/43807659/c44f8fef-e87e-4ae9-9daa-ec11010707ab)

'Currently `Buffer::present` must block copying image data on:' is meant to be a new heading for the last two dot-points, but currently gets interpreted as part of the dot-point for Orbital since there's no line break before it. This PR fixes that, making it look like it's supposed to:

![Screenshot 2023-10-29 at 5 45 33 pm](https://github.com/rust-windowing/softbuffer/assets/43807659/6b872d88-25f9-4b22-b272-e7b35b3f1d55)

