### PR TITLE
examples/fruit: Make draw logic act on `RedrawRequested` instead of `Close` again

### DIFF
--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -41,7 +41,7 @@ fn main() {
             match event {
                 Event::WindowEvent {
                     window_id,
-                    event: WindowEvent::CloseRequested,
+                    event: WindowEvent::RedrawRequested,
                 } if window_id == window.id() => {
                     surface
                         .resize(


### PR DESCRIPTION
It seems #132 contains a copy-paste typo to trigger draw logic on `CloseRequested` instead of on `RedrawRequested`.

CC @notgull @daxpedda 