### PR TITLE
examples: Trigger event-loop exit on `Escape` key

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -4,8 +4,9 @@ use rayon::prelude::*;
 use std::f64::consts::PI;
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use winit::event::{Event, WindowEvent};
+use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::WindowBuilder;
 
 fn main() {
@@ -65,7 +66,16 @@ fn main() {
                     window.request_redraw();
                 }
                 Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
                     window_id,
                 } if window_id == window.id() => {
                     elwt.exit();

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -1,8 +1,9 @@
 use image::GenericImageView;
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use winit::event::{Event, WindowEvent};
+use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::WindowBuilder;
 
 fn main() {
@@ -64,7 +65,16 @@ fn main() {
                     buffer.present().unwrap();
                 }
                 Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
                     window_id,
                 } if window_id == window.id() => {
                     elwt.exit();

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 use std::rc::Rc;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
-use winit::keyboard::{KeyCode, PhysicalKey};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::WindowBuilder;
 
 fn redraw(buffer: &mut [u32], width: usize, height: usize, flag: bool) {
@@ -80,7 +80,16 @@ fn main() {
                 }
 
                 Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
                     window_id,
                 } if window_id == window.id() => {
                     elwt.exit();
@@ -92,7 +101,7 @@ fn main() {
                             event:
                                 KeyEvent {
                                     state: ElementState::Pressed,
-                                    physical_key: PhysicalKey::Code(KeyCode::Space),
+                                    logical_key: Key::Named(NamedKey::Space),
                                     ..
                                 },
                             ..

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use winit::event::{Event, WindowEvent};
+use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::WindowBuilder;
 
 fn main() {
@@ -55,7 +56,16 @@ fn main() {
                     }
                 }
                 Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
                     window_id,
                 } if window_id == window.id() => {
                     elwt.exit();

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use winit::event::{Event, WindowEvent};
+use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::WindowBuilder;
 
 const BUFFER_WIDTH: usize = 256;
@@ -58,7 +59,16 @@ fn main() {
                     buffer.present().unwrap();
                 }
                 Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
                     window_id,
                 } if window_id == window.id() => {
                     elwt.exit();


### PR DESCRIPTION
In visual examples it is convenient to just press the escape key to exit the demo.
