### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-# Unreleased
+# 0.4.0
 
-* **Breaking:** Port to use `raw-window-handle` v0.6.
+- **Breaking:** Port to use `raw-window-handle` v0.6.(#132)
+- Enable creating X11 displays without an existing connection. (#171)
+
+# 0.3.3
+
+- Fix a bug in the new shared memory model in X11. (#170)
 
 # 0.3.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"


### PR DESCRIPTION
- **Breaking:** Port to use `raw-window-handle` v0.6.(#132)
- Enable creating X11 displays without an existing connection. (#171)
