### PR TITLE
Update `drm` to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ raw_window_handle = { package = "raw-window-handle", version = "0.6", features =
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
 as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
-drm = { version = "0.10.0", default-features = false, optional = true }
+drm = { version = "0.11.0", default-features = false, optional = true }
 fastrand = { version = "2.0.0", optional = true }
 memmap2 = { version = "0.9.0", optional = true }
 rustix = { version = "0.38.19", features = ["fs", "mm", "shm", "std"], default-features = false, optional = true }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -340,8 +340,7 @@ impl<D: ?Sized, W: ?Sized> BufferImpl<'_, D, W> {
         // returns `ENOSYS` and check that before allocating the above and running this.
         match self.display.dirty_framebuffer(self.front_fb, &rectangles) {
             Ok(()) => {}
-            Err(drm::SystemError::Unknown { errno })
-                if errno as i32 == rustix::io::Errno::NOSYS.raw_os_error() => {}
+            Err(e) if e.raw_os_error() == Some(rustix::io::Errno::NOSYS.raw_os_error()) => {}
             Err(e) => {
                 return Err(SoftBufferError::PlatformError(
                     Some("failed to dirty framebuffer".into()),


### PR DESCRIPTION
Drm-rs now no longer requires separate generated bindings for each platform, so this fixes the build on architectures/OSes where drm didn't have bindings.

It also now uses Rustix instead of Nix, but Nix is still used by the Wayland and X11 backends, until the next wayland-rs and x11rb release.

This is not a breaking change since `drm` isn't exposed in the API.