### PR TITLE
macOS: Fix double-free of `NSWindow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- MacOS: Fix double-free of `NSWindow`.
+
 # 0.4.0
 
 - **Breaking:** Port to use `raw-window-handle` v0.6.(#132)

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -42,7 +42,8 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> CGImpl<D, W> {
             _ => return Err(InitError::Unsupported(window_src)),
         };
         let view = handle.ns_view.as_ptr() as id;
-        let window = unsafe { msg_send![view, window] };
+        let window: id = unsafe { msg_send![view, window] };
+        let window: id = unsafe { msg_send![window, retain] };
         let layer = CALayer::new();
         unsafe {
             let subview: id = NSView::alloc(nil).initWithFrame_(NSView::frame(view));


### PR DESCRIPTION
See https://github.com/rust-windowing/softbuffer/pull/179#issuecomment-1811643510 for the diagnosing.