### PR TITLE
WIP Format API

### DIFF
--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -24,7 +24,8 @@ fn main() {
     }
 
     let context = softbuffer::Context::new(window.clone()).unwrap();
-    let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+    let mut surface =
+        softbuffer::Surface::new(&context, window.clone(), softbuffer::Format::BGRX).unwrap();
 
     event_loop
         .run(move |event, elwt| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,6 +92,9 @@ pub enum SoftBufferError {
         rect: crate::Rect,
     },
 
+    /// The requested format is not supported by the display.
+    UnsupportedFormat { format: crate::Format },
+
     /// A platform-specific backend error occurred.
     ///
     /// The first field provides a human-readable description of the error. The second field
@@ -138,6 +141,7 @@ impl fmt::Display for SoftBufferError {
                 "Damage rect {}x{} at ({}, {}) out of range for backend.",
                 rect.width, rect.height, rect.x, rect.y
             ),
+            Self::UnsupportedFormat { format } => write!(f, "Format {:?} unsupported on display.", format),
             Self::Unimplemented => write!(f, "This function is unimplemented on this platform."),
         }
     }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -18,6 +18,7 @@ use std::os::unix::io::{AsFd, BorrowedFd};
 use std::rc::Rc;
 
 use crate::error::{InitError, SoftBufferError, SwResultExt};
+use crate::Format;
 
 #[derive(Debug)]
 pub(crate) struct KmsDisplayImpl<D: ?Sized> {
@@ -54,6 +55,10 @@ impl<D: HasDisplayHandle> KmsDisplayImpl<D> {
             fd,
             _display: display,
         })
+    }
+
+    pub(crate) fn formats(&self) -> Vec<Format> {
+        vec![Format::BGRX]
     }
 }
 

--- a/src/wayland/buffer.rs
+++ b/src/wayland/buffer.rs
@@ -81,7 +81,13 @@ pub(super) struct WaylandBuffer {
 }
 
 impl WaylandBuffer {
-    pub fn new(shm: &wl_shm::WlShm, width: i32, height: i32, qh: &QueueHandle<State>) -> Self {
+    pub fn new(
+        shm: &wl_shm::WlShm,
+        format: wl_shm::Format,
+        width: i32,
+        height: i32,
+        qh: &QueueHandle<State>,
+    ) -> Self {
         // Calculate size to use for shm pool
         let pool_size = get_pool_size(width, height);
 
@@ -93,15 +99,7 @@ impl WaylandBuffer {
         // Create wayland shm pool and buffer
         let pool = shm.create_pool(tempfile.as_fd(), pool_size, qh, ());
         let released = Arc::new(AtomicBool::new(true));
-        let buffer = pool.create_buffer(
-            0,
-            width,
-            height,
-            width * 4,
-            wl_shm::Format::Xrgb8888,
-            qh,
-            released.clone(),
-        );
+        let buffer = pool.create_buffer(0, width, height, width * 4, format, qh, released.clone());
 
         Self {
             qh: qh.clone(),

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::uninlined_format_args)]
 
 use crate::error::{InitError, SwResultExt};
-use crate::{Rect, SoftBufferError};
+use crate::{Format, Rect, SoftBufferError};
 use raw_window_handle::{
     HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle, XcbDisplayHandle,
     XcbWindowHandle,
@@ -112,6 +112,10 @@ impl<D: HasDisplayHandle + ?Sized> X11DisplayImpl<D> {
             supported_visuals,
             _display: display,
         })
+    }
+
+    pub(crate) fn formats(&self) -> Vec<Format> {
+        vec![Format::BGRX]
     }
 }
 


### PR DESCRIPTION
Very initial implementation for https://github.com/rust-windowing/softbuffer/issues/98. No conversion support, and Wayland only, but allows listing available formats and selecting which to use. Seems good to get a start on this and see how things work.

It should be easy to add basic format conversion support swapping the first and third component. I'm not sure exactly about alpha. If a platform always uses alpha, a format like `BGRX` can't be supported without conversion (setting the fourth component to 255). If a platform doesn't support alpha, formats with alpha probably shouldn't be supported even with conversion? Instead of just listing `Format`, it could list structs with that and a `native: bool` field to indicate that the format is native and doesn't require conversion...