### PR TITLE
0.3 backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.4
+* Fix buffer age on Wayland. (#191)
+* Update `drm` to 0.11. (#178)
+  * Fixes build on architectures where drm-rs did not have generated bindings.
+
 # 0.3.3
 * Fix bad file descriptor crash on X11. (#168)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ raw-window-handle = "0.5.0"
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
 as-raw-xcb-connection = { version = "1.0.0", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
-drm = { version = "0.10.0", default-features = false, optional = true }
+drm = { version = "0.11.0", default-features = false, optional = true }
 fastrand = { version = "2.0.0", optional = true }
 memmap2 = { version = "0.9.0", optional = true }
 rustix = { version = "0.38.19", features = ["fs", "mm", "shm", "std"], default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -333,8 +333,7 @@ impl BufferImpl<'_> {
         // returns `ENOSYS` and check that before allocating the above and running this.
         match self.display.dirty_framebuffer(self.front_fb, &rectangles) {
             Ok(()) => {}
-            Err(drm::SystemError::Unknown { errno })
-                if errno as i32 == rustix::io::Errno::NOSYS.raw_os_error() => {}
+            Err(e) if e.raw_os_error() == Some(rustix::io::Errno::NOSYS.raw_os_error()) => {}
             Err(e) => {
                 return Err(SoftBufferError::PlatformError(
                     Some("failed to dirty framebuffer".into()),

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -147,13 +147,13 @@ impl WaylandImpl {
             .dispatch_pending(&mut State);
 
         if let Some((front, back)) = &mut self.buffers {
+            // Swap front and back buffer
+            std::mem::swap(front, back);
+
             front.age = 1;
             if back.age != 0 {
                 back.age += 1;
             }
-
-            // Swap front and back buffer
-            std::mem::swap(front, back);
 
             front.attach(&self.surface);
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -8,7 +8,10 @@
 use crate::error::SwResultExt;
 use crate::{Rect, SoftBufferError};
 use raw_window_handle::{XcbDisplayHandle, XcbWindowHandle, XlibDisplayHandle, XlibWindowHandle};
-use rustix::{fd::{AsFd, BorrowedFd, OwnedFd}, mm, shm as posix_shm};
+use rustix::{
+    fd::{AsFd, BorrowedFd, OwnedFd},
+    mm, shm as posix_shm,
+};
 
 use std::{
     fmt,


### PR DESCRIPTION
A new 0.3 release is useful for anything still relying on raw-window-handle 0.5. Given it isn't too hard. In particular https://github.com/iced-rs/iced/pull/2190.

Is https://github.com/rust-windowing/softbuffer/pull/180 also needed here? Or was that issue introduced later? Easy enough to add.

Leaving as a draft until I test on macOS (and make sure nothing has buffer age bugs now?). And we should also do a 0.4.x release with the current fixes.