### PR TITLE
Add ability to get underlying window handle

### DIFF
--- a/src/cg.rs
+++ b/src/cg.rs
@@ -68,13 +68,13 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> CGImpl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -72,12 +72,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> CGImpl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         self.size = Some((width, height));
         Ok(())

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -30,7 +30,7 @@ pub struct CGImpl<D, W> {
     window: id,
     color_space: CGColorSpace,
     size: Option<(NonZeroU32, NonZeroU32)>,
-    _window_source: W,
+    window_handle: W,
     _display: PhantomData<D>,
 }
 
@@ -62,8 +62,20 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> CGImpl<D, W> {
             color_space,
             size: None,
             _display: PhantomData,
-            _window_source: window_src,
+            window_handle: window_src,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -206,13 +206,13 @@ impl<D: ?Sized, W: HasWindowHandle> KmsImpl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -73,7 +73,7 @@ pub(crate) struct KmsImpl<D: ?Sized, W: ?Sized> {
     buffer: Option<Buffers>,
 
     /// Window handle that we are keeping around.
-    _window: W,
+    window_handle: W,
 }
 
 #[derive(Debug)]
@@ -200,8 +200,20 @@ impl<D: ?Sized, W: HasWindowHandle> KmsImpl<D, W> {
             connectors,
             display,
             buffer: None,
-            _window: window,
+            window_handle: window,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     /// Resize the internal buffer to the given size.

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -210,12 +210,6 @@ impl<D: ?Sized, W: HasWindowHandle> KmsImpl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     /// Resize the internal buffer to the given size.
     pub(crate) fn resize(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,24 @@ macro_rules! make_dispatch {
         }
 
         impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceDispatch<D, W> {
+            fn get_ref(&self) -> &W {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.get_ref(),
+                    )*
+                }
+            }
+
+            fn get_mut(&mut self) -> &mut W {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.get_mut(),
+                    )*
+                }
+            }
+
             pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
                 match self {
                     $(
@@ -311,6 +329,16 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
         })
     }
 
+    /// Get a reference to the underlying window handle.
+    pub fn get_ref(&self) -> &W {
+        self.surface_impl.get_ref()
+    }
+
+    /// Get a mutable reference to the underlying window handle.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.surface_impl.get_mut()
+    }
+
     /// Set the size of the buffer that will be returned by [`Surface::buffer_mut`].
     ///
     /// If the size of the buffer does not match the size of the window, the buffer is drawn
@@ -347,6 +375,29 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
             buffer_impl: self.surface_impl.buffer_mut()?,
             _marker: PhantomData,
         })
+    }
+}
+
+impl<D: HasDisplayHandle, W: HasWindowHandle> AsRef<W> for Surface<D, W> {
+    #[inline]
+    fn as_ref(&self) -> &W {
+        self.get_ref()
+    }
+}
+
+impl<D: HasDisplayHandle, W: HasWindowHandle> AsMut<W> for Surface<D, W> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut W {
+        self.get_mut()
+    }
+}
+
+impl<D: HasDisplayHandle, W: HasWindowHandle> HasWindowHandle for Surface<D, W> {
+    #[inline]
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        self.get_ref().window_handle()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,15 +95,6 @@ macro_rules! make_dispatch {
                 }
             }
 
-            fn window_mut(&mut self) -> &mut W {
-                match self {
-                    $(
-                        $(#[$attr])*
-                        Self::$name(inner) => inner.window_mut(),
-                    )*
-                }
-            }
-
             pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
                 match self {
                     $(
@@ -334,11 +325,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
         self.surface_impl.window()
     }
 
-    /// Get a mutable reference to the underlying window handle.
-    pub fn window_mut(&mut self) -> &mut W {
-        self.surface_impl.window_mut()
-    }
-
     /// Set the size of the buffer that will be returned by [`Surface::buffer_mut`].
     ///
     /// If the size of the buffer does not match the size of the window, the buffer is drawn
@@ -382,13 +368,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> AsRef<W> for Surface<D, W> {
     #[inline]
     fn as_ref(&self) -> &W {
         self.window()
-    }
-}
-
-impl<D: HasDisplayHandle, W: HasWindowHandle> AsMut<W> for Surface<D, W> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut W {
-        self.window_mut()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,20 +86,20 @@ macro_rules! make_dispatch {
         }
 
         impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceDispatch<D, W> {
-            fn get_ref(&self) -> &W {
+            fn window(&self) -> &W {
                 match self {
                     $(
                         $(#[$attr])*
-                        Self::$name(inner) => inner.get_ref(),
+                        Self::$name(inner) => inner.window(),
                     )*
                 }
             }
 
-            fn get_mut(&mut self) -> &mut W {
+            fn window_mut(&mut self) -> &mut W {
                 match self {
                     $(
                         $(#[$attr])*
-                        Self::$name(inner) => inner.get_mut(),
+                        Self::$name(inner) => inner.window_mut(),
                     )*
                 }
             }
@@ -330,13 +330,13 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
     }
 
     /// Get a reference to the underlying window handle.
-    pub fn get_ref(&self) -> &W {
-        self.surface_impl.get_ref()
+    pub fn window(&self) -> &W {
+        self.surface_impl.window()
     }
 
     /// Get a mutable reference to the underlying window handle.
-    pub fn get_mut(&mut self) -> &mut W {
-        self.surface_impl.get_mut()
+    pub fn window_mut(&mut self) -> &mut W {
+        self.surface_impl.window_mut()
     }
 
     /// Set the size of the buffer that will be returned by [`Surface::buffer_mut`].
@@ -381,14 +381,14 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
 impl<D: HasDisplayHandle, W: HasWindowHandle> AsRef<W> for Surface<D, W> {
     #[inline]
     fn as_ref(&self) -> &W {
-        self.get_ref()
+        self.window()
     }
 }
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> AsMut<W> for Surface<D, W> {
     #[inline]
     fn as_mut(&mut self) -> &mut W {
-        self.get_mut()
+        self.window_mut()
     }
 }
 
@@ -397,7 +397,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> HasWindowHandle for Surface<D, W> 
     fn window_handle(
         &self,
     ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
-        self.get_ref().window_handle()
+        self.window().window_handle()
     }
 }
 

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -59,7 +59,7 @@ pub struct OrbitalImpl<D, W> {
     width: u32,
     height: u32,
     presented: bool,
-    _window_source: W,
+    window_handle: W,
     _display: PhantomData<D>,
 }
 
@@ -76,9 +76,21 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
             width: 0,
             height: 0,
             presented: false,
-            _window_source: window,
+            window_handle: window,
             _display: PhantomData,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -87,12 +87,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         let width = width.get();
         let height = height.get();

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -83,13 +83,13 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -115,13 +115,13 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> WaylandImpl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -119,12 +119,6 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> WaylandImpl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         self.size = Some(
             (|| {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -83,7 +83,7 @@ pub struct WaylandImpl<D: ?Sized, W: ?Sized> {
     ///
     /// This has to be dropped *after* the `surface` field, because the `surface` field implicitly
     /// borrows this.
-    _window: W,
+    window_handle: W,
 }
 
 impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> WaylandImpl<D, W> {
@@ -109,8 +109,20 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> WaylandImpl<D, W> {
             surface: Some(surface),
             buffers: Default::default(),
             size: None,
-            _window: window,
+            window_handle: window,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {

--- a/src/web.rs
+++ b/src/web.rs
@@ -57,7 +57,7 @@ pub struct WebImpl<D, W> {
     size: Option<(NonZeroU32, NonZeroU32)>,
 
     /// The underlying window handle.
-    _window: W,
+    window_handle: W,
 
     /// The underlying display handle.
     _display: PhantomData<D>,
@@ -114,7 +114,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
             buffer: Vec::new(),
             buffer_presented: false,
             size: None,
-            _window: window,
+            window_handle: window,
             _display: PhantomData,
         })
     }
@@ -130,9 +130,21 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
             buffer: Vec::new(),
             buffer_presented: false,
             size: None,
-            _window: window,
+            window_handle: window,
             _display: PhantomData,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     /// De-duplicates the error handling between `HtmlCanvasElement` and `OffscreenCanvas`.

--- a/src/web.rs
+++ b/src/web.rs
@@ -141,12 +141,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     /// De-duplicates the error handling between `HtmlCanvasElement` and `OffscreenCanvas`.
     fn resolve_ctx<T: JsCast>(
         result: Option<Option<Object>>,

--- a/src/web.rs
+++ b/src/web.rs
@@ -137,13 +137,13 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -142,7 +142,7 @@ pub struct Win32Impl<D: ?Sized, W> {
     /// The handle for the window.
     ///
     /// This should be kept alive in order to keep `window` valid.
-    _window: W,
+    handle: W,
 
     /// The display handle.
     ///
@@ -184,9 +184,21 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Win32Impl<D, W> {
             dc,
             window: hwnd,
             buffer: None,
-            _window: window,
+            handle: window,
             _display: PhantomData,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.handle
     }
 
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -195,12 +195,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Win32Impl<D, W> {
         &self.handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.handle
-    }
-
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         let (width, height) = (|| {
             let width = NonZeroI32::new(i32::try_from(width.get()).ok()?)?;

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -191,13 +191,13 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Win32Impl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.handle
     }
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -150,7 +150,7 @@ pub struct X11Impl<D: ?Sized, W: ?Sized> {
     size: Option<(NonZeroU16, NonZeroU16)>,
 
     /// Keep the window alive.
-    _window_handle: W,
+    window_handle: W,
 }
 
 /// The buffer that is being drawn to.
@@ -292,8 +292,20 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> X11Impl<D, W> {
             buffer,
             buffer_presented: false,
             size: None,
-            _window_handle: window_src,
+            window_handle: window_src,
         })
+    }
+
+    /// Get the inner window handle.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.window_handle
+    }
+
+    /// Get a mutable reference to the inner window handle.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.window_handle
     }
 
     /// Resize the internal buffer to the given width and height.

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -302,12 +302,6 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> X11Impl<D, W> {
         &self.window_handle
     }
 
-    /// Get a mutable reference to the inner window handle.
-    #[inline]
-    pub fn window_mut(&mut self) -> &mut W {
-        &mut self.window_handle
-    }
-
     /// Resize the internal buffer to the given width and height.
     pub(crate) fn resize(
         &mut self,

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -298,13 +298,13 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> X11Impl<D, W> {
 
     /// Get the inner window handle.
     #[inline]
-    pub fn get_ref(&self) -> &W {
+    pub fn window(&self) -> &W {
         &self.window_handle
     }
 
     /// Get a mutable reference to the inner window handle.
     #[inline]
-    pub fn get_mut(&mut self) -> &mut W {
+    pub fn window_mut(&mut self) -> &mut W {
         &mut self.window_handle
     }
 


### PR DESCRIPTION
Adds the `get_ref` and `get_mut` functions, which can be used to get
references (mutable or otherwise) to the underlying window handle.

cc https://github.com/rust-windowing/raw-window-handle/issues/158#issuecomment-1881376603
