### PR TITLE
Set up an autorelease pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'rust-windowing'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - run: |
+        cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+        cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,5 @@ jobs:
           branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      - run: |
-        cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
-        cargo publish
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}


### PR DESCRIPTION
This commit adds a pipeline that automatically creates a GitHub Release
and a crates.io release when a tag is pushed.
