### PR TITLE
On Orbital, fix window resize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update `drm` to 0.11 (#178)
   * Fixes build on architectures where drm-rs did not have generated bindings.
 - Update x11rb to v0.13 (#183)
+- On Orbital, fix window resize.
 
 # 0.4.0
 

--- a/src/orbital.rs
+++ b/src/orbital.rs
@@ -90,7 +90,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
     pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
         let width = width.get();
         let height = height.get();
-        if width != self.width && height != self.height {
+        if width != self.width || height != self.height {
             self.presented = false;
             self.width = width;
             self.height = height;


### PR DESCRIPTION
Previously it tested if both the width AND height were changed before updating the size when it should update if width OR height were changed.