### PR TITLE
Fix Web CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,17 @@ jobs:
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
       run: sudo apt-get install gcc-multilib
 
+    - name: Pin deps that break MSRV
+      if: matrix.rust_version == '1.65.0'
+      run: |
+        cargo update -p exr --precise 1.71.0
+        cargo update -p ahash --precise 0.8.7
+        cargo update -p bumpalo --precise 3.14.0
+  
     - name: Build crate
       shell: bash
       run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
-    - name: Pin versions of dev-deps
-      if: matrix.rust_version == '1.65.0'
-      run: cargo update -p exr --precise 1.71.0 && cargo update -p ahash --precise 0.8.7
-  
     - name: Build tests
       shell: bash
       if: >

--- a/src/backends/web.rs
+++ b/src/backends/web.rs
@@ -12,7 +12,6 @@ use web_sys::{OffscreenCanvas, OffscreenCanvasRenderingContext2d};
 use crate::backend_interface::*;
 use crate::error::{InitError, SwResultExt};
 use crate::{util, NoDisplayHandle, NoWindowHandle, Rect, SoftBufferError};
-use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
@@ -154,6 +153,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
         );
 
         #[cfg(target_feature = "atomics")]
+        #[allow(non_local_definitions)]
         let result = {
             // When using atomics, the underlying memory becomes `SharedArrayBuffer`,
             // which can't be shared with `ImageData`.


### PR DESCRIPTION
This pins `bumpalo` to fix the MSRV check in our CI.

See https://github.com/rust-windowing/raw-window-handle/pull/162, which encountered similar issues.