### PR TITLE
Implement Send and Sync for softbuffer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bytemuck = { version = "1.12.3", features = ["extern_crate_alloc"] }
 core-graphics = "0.23.1"
 foreign-types = "0.5.0"
 objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", features = ["NSThread"] }
+objc2-foundation = { version = "0.2.0", features = ["dispatch", "NSThread"] }
 objc2-app-kit = { version = "0.2.0", features = ["NSResponder", "NSView", "NSWindow"] }
 objc2-quartz-core = { version = "0.2.0", features = ["CALayer", "CATransaction"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ x11rb = { version = "0.13.0", features = ["allow-unsafe-code", "shm"], optional 
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.52.0"
-features = ["Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
+features = ["Win32_Graphics_Gdi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bytemuck = { version = "1.12.3", features = ["extern_crate_alloc"] }

--- a/examples/utils/winit_app.rs
+++ b/examples/utils/winit_app.rs
@@ -13,12 +13,13 @@ mod winit_app {
     pub(crate) fn run_app(event_loop: EventLoop<()>, mut app: impl ApplicationHandler<()> + 'static) {
         #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
         event_loop.run_app(&mut app).unwrap();
-        
+
         #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
         winit::platform::web::EventLoopExtWebSys::spawn_app(event_loop, app);
     }
 
     /// Create a window from a set of window attributes.
+    #[allow(dead_code)]
     pub(crate) fn make_window(elwt: &ActiveEventLoop, f: impl FnOnce(WindowAttributes) -> WindowAttributes) -> Rc<Window> {
         let attributes = f(WindowAttributes::default());
         #[cfg(target_arch = "wasm32")]
@@ -29,7 +30,7 @@ mod winit_app {
         let window = elwt.create_window(attributes);
         Rc::new(window.unwrap())
     }
-    
+
     /// Easily constructable winit application.
     pub(crate) struct WinitApp<T, Init, Handler> {
         /// Closure to initialize state.
@@ -51,7 +52,7 @@ mod winit_app {
         _marker: PhantomData<Option<T>>,
     }
 
-    impl<T, Init> WinitAppBuilder<T, Init> 
+    impl<T, Init> WinitAppBuilder<T, Init>
     where Init: FnMut(&ActiveEventLoop) -> T,
     {
         /// Create with an "init" closure.
@@ -70,7 +71,7 @@ mod winit_app {
         }
     }
 
-    impl<T, Init, Handler> WinitApp<T, Init, Handler> 
+    impl<T, Init, Handler> WinitApp<T, Init, Handler>
     where Init: FnMut(&ActiveEventLoop) -> T,
           Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop)
     {
@@ -84,7 +85,7 @@ mod winit_app {
         }
     }
 
-    impl<T, Init, Handler> ApplicationHandler for WinitApp<T, Init, Handler> 
+    impl<T, Init, Handler> ApplicationHandler for WinitApp<T, Init, Handler>
     where Init: FnMut(&ActiveEventLoop) -> T,
           Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop) {
 
@@ -97,7 +98,7 @@ mod winit_app {
             let state = self.state.take();
             debug_assert!(state.is_some());
             drop(state);
-        }        
+        }
 
         fn window_event(
             &mut self,

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -9,9 +9,6 @@ use winit::window::Window;
 
 include!("utils/winit_app.rs");
 
-const BUFFER_WIDTH: usize = 256;
-const BUFFER_HEIGHT: usize = 128;
-
 type Surface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
 
 fn render_thread(
@@ -87,7 +84,7 @@ fn main() {
         (window, surface, start_render, finish_render)
     })
     .with_event_handler(|state, event, elwt| {
-        let (window, surface, start_render, finish_render) = state;
+        let (window, _surface, start_render, finish_render) = state;
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -1,119 +1,133 @@
 //! `Surface` implements `Send`. This makes sure that multithreading can work here.
 
-use std::num::NonZeroU32;
-use std::sync::{mpsc, Arc, Mutex};
-use winit::event::{Event, KeyEvent, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
-use winit::keyboard::{Key, NamedKey};
-use winit::window::Window;
+#[cfg(not(target_family = "wasm"))]
+mod ex {
+    use std::num::NonZeroU32;
+    use std::sync::{mpsc, Arc, Mutex};
+    use winit::event::{Event, KeyEvent, WindowEvent};
+    use winit::event_loop::{ControlFlow, EventLoop};
+    use winit::keyboard::{Key, NamedKey};
+    use winit::window::Window;
 
-include!("utils/winit_app.rs");
+    include!("utils/winit_app.rs");
 
-type Surface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
+    type Surface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
 
-fn render_thread(
-    window: Arc<Window>,
-    surface: Arc<Mutex<Surface>>,
-    do_render: mpsc::Receiver<()>,
-    done: mpsc::Sender<()>,
-) {
-    loop {
-        println!("waiting for render...");
-        if do_render.recv().is_err() {
-            // Main thread is dead.
-            break;
-        }
-
-        // Perform the rendering.
-        let mut surface = surface.lock().unwrap();
-        if let (Some(width), Some(height)) = {
-            let size = window.inner_size();
-            println!("got size: {size:?}");
-            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-        } {
-            println!("resizing...");
-            surface.resize(width, height).unwrap();
-
-            let mut buffer = surface.buffer_mut().unwrap();
-            for y in 0..height.get() {
-                for x in 0..width.get() {
-                    let red = x % 255;
-                    let green = y % 255;
-                    let blue = (x * y) % 255;
-                    let index = y as usize * width.get() as usize + x as usize;
-                    buffer[index] = blue | (green << 8) | (red << 16);
-                }
+    fn render_thread(
+        window: Arc<Window>,
+        surface: Arc<Mutex<Surface>>,
+        do_render: mpsc::Receiver<()>,
+        done: mpsc::Sender<()>,
+    ) {
+        loop {
+            println!("waiting for render...");
+            if do_render.recv().is_err() {
+                // Main thread is dead.
+                break;
             }
 
-            println!("presenting...");
-            buffer.present().unwrap();
-        }
+            // Perform the rendering.
+            let mut surface = surface.lock().unwrap();
+            if let (Some(width), Some(height)) = {
+                let size = window.inner_size();
+                println!("got size: {size:?}");
+                (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+            } {
+                println!("resizing...");
+                surface.resize(width, height).unwrap();
 
-        // We're done, tell the main thread to keep going.
-        done.send(()).ok();
+                let mut buffer = surface.buffer_mut().unwrap();
+                for y in 0..height.get() {
+                    for x in 0..width.get() {
+                        let red = x % 255;
+                        let green = y % 255;
+                        let blue = (x * y) % 255;
+                        let index = y as usize * width.get() as usize + x as usize;
+                        buffer[index] = blue | (green << 8) | (red << 16);
+                    }
+                }
+
+                println!("presenting...");
+                buffer.present().unwrap();
+            }
+
+            // We're done, tell the main thread to keep going.
+            done.send(()).ok();
+        }
+    }
+
+    pub(super) fn entry() {
+        let event_loop = EventLoop::new().unwrap();
+
+        let app = winit_app::WinitAppBuilder::with_init(|elwt| {
+            let attributes = Window::default_attributes();
+            #[cfg(target_arch = "wasm32")]
+            let attributes =
+                winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
+            let window = Arc::new(elwt.create_window(attributes).unwrap());
+
+            let context = softbuffer::Context::new(window.clone()).unwrap();
+            let surface = {
+                println!("making surface...");
+                let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+                Arc::new(Mutex::new(surface))
+            };
+
+            // Spawn a thread to handle rendering.
+            let (start_render, do_render) = mpsc::channel();
+            let (render_done, finish_render) = mpsc::channel();
+            println!("starting thread...");
+            std::thread::spawn({
+                let window = window.clone();
+                let surface = surface.clone();
+                move || render_thread(window, surface, do_render, render_done)
+            });
+
+            (window, surface, start_render, finish_render)
+        })
+        .with_event_handler(|state, event, elwt| {
+            let (window, _surface, start_render, finish_render) = state;
+            elwt.set_control_flow(ControlFlow::Wait);
+
+            match event {
+                Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::RedrawRequested,
+                } if window_id == window.id() => {
+                    // Start the render and then finish it.
+                    start_render.send(()).unwrap();
+                    finish_render.recv().unwrap();
+                }
+                Event::WindowEvent {
+                    event:
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key: Key::Named(NamedKey::Escape),
+                                    ..
+                                },
+                            ..
+                        },
+                    window_id,
+                } if window_id == window.id() => {
+                    elwt.exit();
+                }
+                _ => {}
+            }
+        });
+
+        winit_app::run_app(event_loop, app);
+    }
+}
+
+#[cfg(target_family = "wasm")]
+mod ex {
+    pub(crate) fn entry() {
+        eprintln!("winit_multithreaded doesn't work on WASM");
     }
 }
 
 fn main() {
-    let event_loop = EventLoop::new().unwrap();
-
-    let app = winit_app::WinitAppBuilder::with_init(|elwt| {
-        let attributes = Window::default_attributes();
-        #[cfg(target_arch = "wasm32")]
-        let attributes =
-            winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
-        let window = Arc::new(elwt.create_window(attributes).unwrap());
-
-        let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = {
-            println!("making surface...");
-            let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
-            Arc::new(Mutex::new(surface))
-        };
-
-        // Spawn a thread to handle rendering.
-        let (start_render, do_render) = mpsc::channel();
-        let (render_done, finish_render) = mpsc::channel();
-        println!("starting thread...");
-        std::thread::spawn({
-            let window = window.clone();
-            let surface = surface.clone();
-            move || render_thread(window, surface, do_render, render_done)
-        });
-
-        (window, surface, start_render, finish_render)
-    })
-    .with_event_handler(|state, event, elwt| {
-        let (window, _surface, start_render, finish_render) = state;
-        elwt.set_control_flow(ControlFlow::Wait);
-
-        match event {
-            Event::WindowEvent {
-                window_id,
-                event: WindowEvent::RedrawRequested,
-            } if window_id == window.id() => {
-                // Start the render and then finish it.
-                start_render.send(()).unwrap();
-                finish_render.recv().unwrap();
-            }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::CloseRequested
-                    | WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Named(NamedKey::Escape),
-                                ..
-                            },
-                        ..
-                    },
-                window_id,
-            } if window_id == window.id() => {
-                elwt.exit();
-            }
-            _ => {}
-        }
-    });
-
-    winit_app::run_app(event_loop, app);
+    ex::entry();
 }

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -1,0 +1,122 @@
+//! `Surface` implements `Send`. This makes sure that multithreading can work here.
+
+use std::num::NonZeroU32;
+use std::sync::{mpsc, Arc, Mutex};
+use winit::event::{Event, KeyEvent, WindowEvent};
+use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
+use winit::window::Window;
+
+include!("utils/winit_app.rs");
+
+const BUFFER_WIDTH: usize = 256;
+const BUFFER_HEIGHT: usize = 128;
+
+type Surface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
+
+fn render_thread(
+    window: Arc<Window>,
+    surface: Arc<Mutex<Surface>>,
+    do_render: mpsc::Receiver<()>,
+    done: mpsc::Sender<()>,
+) {
+    loop {
+        println!("waiting for render...");
+        if do_render.recv().is_err() {
+            // Main thread is dead.
+            break;
+        }
+
+        // Perform the rendering.
+        let mut surface = surface.lock().unwrap();
+        if let (Some(width), Some(height)) = {
+            let size = window.inner_size();
+            println!("got size: {size:?}");
+            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+        } {
+            println!("resizing...");
+            surface.resize(width, height).unwrap();
+
+            let mut buffer = surface.buffer_mut().unwrap();
+            for y in 0..height.get() {
+                for x in 0..width.get() {
+                    let red = x % 255;
+                    let green = y % 255;
+                    let blue = (x * y) % 255;
+                    let index = y as usize * width.get() as usize + x as usize;
+                    buffer[index] = blue | (green << 8) | (red << 16);
+                }
+            }
+
+            println!("presenting...");
+            buffer.present().unwrap();
+        }
+
+        // We're done, tell the main thread to keep going.
+        done.send(()).ok();
+    }
+}
+
+fn main() {
+    let event_loop = EventLoop::new().unwrap();
+
+    let app = winit_app::WinitAppBuilder::with_init(|elwt| {
+        let attributes = Window::default_attributes();
+        #[cfg(target_arch = "wasm32")]
+        let attributes =
+            winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
+        let window = Arc::new(elwt.create_window(attributes).unwrap());
+
+        let context = softbuffer::Context::new(window.clone()).unwrap();
+        let surface = {
+            println!("making surface...");
+            let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+            Arc::new(Mutex::new(surface))
+        };
+
+        // Spawn a thread to handle rendering.
+        let (start_render, do_render) = mpsc::channel();
+        let (render_done, finish_render) = mpsc::channel();
+        println!("starting thread...");
+        std::thread::spawn({
+            let window = window.clone();
+            let surface = surface.clone();
+            move || render_thread(window, surface, do_render, render_done)
+        });
+
+        (window, surface, start_render, finish_render)
+    })
+    .with_event_handler(|state, event, elwt| {
+        let (window, surface, start_render, finish_render) = state;
+        elwt.set_control_flow(ControlFlow::Wait);
+
+        match event {
+            Event::WindowEvent {
+                window_id,
+                event: WindowEvent::RedrawRequested,
+            } if window_id == window.id() => {
+                // Start the render and then finish it.
+                start_render.send(()).unwrap();
+                finish_render.recv().unwrap();
+            }
+            Event::WindowEvent {
+                event:
+                    WindowEvent::CloseRequested
+                    | WindowEvent::KeyboardInput {
+                        event:
+                            KeyEvent {
+                                logical_key: Key::Named(NamedKey::Escape),
+                                ..
+                            },
+                        ..
+                    },
+                window_id,
+            } if window_id == window.id() => {
+                elwt.exit();
+            }
+            _ => {}
+        }
+    });
+
+    winit_app::run_app(event_loop, app);
+}

--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -5,7 +5,7 @@ use crate::{backend_interface::*, backends, InitError, Rect, SoftBufferError};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::num::NonZeroU32;
 #[cfg(any(wayland_platform, x11_platform, kms_platform))]
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// A macro for creating the enum used to statically dispatch to the platform-specific implementation.
 macro_rules! make_dispatch {
@@ -179,11 +179,11 @@ macro_rules! make_dispatch {
 make_dispatch! {
     <D, W> =>
     #[cfg(x11_platform)]
-    X11(Rc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'a, D, W>),
+    X11(Arc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'a, D, W>),
     #[cfg(wayland_platform)]
-    Wayland(Rc<backends::wayland::WaylandDisplayImpl<D>>, backends::wayland::WaylandImpl<D, W>, backends::wayland::BufferImpl<'a, D, W>),
+    Wayland(Arc<backends::wayland::WaylandDisplayImpl<D>>, backends::wayland::WaylandImpl<D, W>, backends::wayland::BufferImpl<'a, D, W>),
     #[cfg(kms_platform)]
-    Kms(Rc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'a, D, W>),
+    Kms(Arc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'a, D, W>),
     #[cfg(target_os = "windows")]
     Win32(D, backends::win32::Win32Impl<D, W>, backends::win32::BufferImpl<'a, D, W>),
     #[cfg(target_os = "macos")]

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -14,7 +14,7 @@ use foreign_types::ForeignType;
 use objc2::msg_send;
 use objc2::rc::Id;
 use objc2_app_kit::{NSAutoresizingMaskOptions, NSView, NSWindow};
-use objc2_foundation::MainThreadMarker;
+use objc2_foundation::{MainThreadBound, MainThreadMarker};
 use objc2_quartz_core::{kCAGravityTopLeft, CALayer, CATransaction};
 
 use std::marker::PhantomData;
@@ -30,9 +30,9 @@ impl AsRef<[u8]> for Buffer {
 }
 
 pub struct CGImpl<D, W> {
-    layer: Id<CALayer>,
-    window: Id<NSWindow>,
-    color_space: CGColorSpace,
+    layer: MainThreadBound<Id<CALayer>>,
+    window: MainThreadBound<Id<NSWindow>>,
+    color_space: SendCGColorSpace,
     size: Option<(NonZeroU32, NonZeroU32)>,
     window_handle: W,
     _display: PhantomData<D>,
@@ -84,9 +84,9 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<
         unsafe { view.addSubview(&subview) };
         let color_space = CGColorSpace::create_device_rgb();
         Ok(Self {
-            layer,
-            window,
-            color_space,
+            layer: MainThreadBound::new(layer, mtm),
+            window: MainThreadBound::new(window, mtm),
+            color_space: SendCGColorSpace(color_space),
             size: None,
             _display: PhantomData,
             window_handle: window_src,
@@ -144,12 +144,18 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
             8,
             32,
             (width.get() * 4) as usize,
-            &self.imp.color_space,
+            &self.imp.color_space.0,
             kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst,
             &data_provider,
             false,
             kCGRenderingIntentDefault,
         );
+
+        // TODO: Use run_on_main() instead.
+        let mtm = MainThreadMarker::new().ok_or(SoftBufferError::PlatformError(
+            Some("can only access AppKit / macOS handles from the main thread".to_string()),
+            None,
+        ))?;
 
         // The CALayer has a default action associated with a change in the layer contents, causing
         // a quarter second fade transition to happen every time a new buffer is applied. This can
@@ -157,14 +163,11 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
         CATransaction::begin();
         CATransaction::setDisableActions(true);
 
-        self.imp
-            .layer
-            .setContentsScale(self.imp.window.backingScaleFactor());
+        let layer = self.imp.layer.get(mtm);
+        layer.setContentsScale(self.imp.window.get(mtm).backingScaleFactor());
 
         unsafe {
-            self.imp
-                .layer
-                .setContents((image.as_ptr() as *mut AnyObject).as_ref());
+            layer.setContents((image.as_ptr() as *mut AnyObject).as_ref());
         };
 
         CATransaction::commit();
@@ -176,3 +179,7 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
         self.present()
     }
 }
+
+struct SendCGColorSpace(CGColorSpace);
+// SAFETY: I'm 99% sure this is thread safe.
+unsafe impl Send for SendCGColorSpace {}

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -181,5 +181,6 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
 }
 
 struct SendCGColorSpace(CGColorSpace);
-// SAFETY: I'm 99% sure this is thread safe.
+// SAFETY: `CGColorSpace` is immutable, and can freely be shared between threads.
 unsafe impl Send for SendCGColorSpace {}
+unsafe impl Sync for SendCGColorSpace {}

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -434,7 +434,7 @@ impl Command {
             }
 
             Self::Release { dc, owner } => {
-                // Release thie DC.
+                // Release this DC.
                 unsafe {
                     Gdi::ReleaseDC(owner, dc);
                 }

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -12,11 +12,11 @@ use std::mem;
 use std::num::{NonZeroI32, NonZeroU32};
 use std::ptr::{self, NonNull};
 use std::slice;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{mpsc, OnceLock};
+use std::thread;
 
 use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::Graphics::Gdi;
-use windows_sys::Win32::UI::{Shell, WindowsAndMessaging as Win};
 
 const ZERO_QUAD: Gdi::RGBQUAD = Gdi::RGBQUAD {
     rgbBlue: 0,
@@ -24,11 +24,8 @@ const ZERO_QUAD: Gdi::RGBQUAD = Gdi::RGBQUAD {
     rgbRed: 0,
     rgbReserved: 0,
 };
-const SUBCLASS_ID: usize = 0xDEADBEEF;
 
 struct Buffer {
-    // Invariant: This window has our custom softbuffer subclass.
-    owner_window: HWND,
     dc: Gdi::HDC,
     bitmap: Gdi::HBITMAP,
     pixels: NonNull<u32>,
@@ -37,26 +34,21 @@ struct Buffer {
     presented: bool,
 }
 
-// SAFETY: We allow no interior mutability here and we drop the HDC on its origin thread.
 unsafe impl Send for Buffer {}
 
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
-            // Delete the DC by posting a message that calls DeleteDC on the origin thread.
-            Win::PostMessageW(
-                self.owner_window,
-                destroy_dc_and_bitmap(),
-                self.dc as usize,
-                self.bitmap,
-            );
+            Gdi::DeleteObject(self.bitmap);
         }
+
+        Allocator::get().deallocate(self.dc);
     }
 }
 
 impl Buffer {
-    fn new(owner: HWND, window_dc: Gdi::HDC, width: NonZeroI32, height: NonZeroI32) -> Self {
-        let dc = unsafe { Win::SendMessageW(owner, get_compatible_dc(), 0, window_dc) };
+    fn new(window_dc: Gdi::HDC, width: NonZeroI32, height: NonZeroI32) -> Self {
+        let dc = Allocator::get().allocate(window_dc);
         assert!(dc != 0);
 
         // Create a new bitmap info struct.
@@ -93,8 +85,6 @@ impl Buffer {
         // XXX alignment?
         // XXX better to use CreateFileMapping, and pass hSection?
         // XXX test return value?
-        // Note: Bitmaps are apparently threadsafe.
-        // https://devblogs.microsoft.com/oldnewthing/20051013-11/?p=33783
         let mut pixels: *mut u32 = ptr::null_mut();
         let bitmap = unsafe {
             Gdi::CreateDIBSection(
@@ -114,7 +104,6 @@ impl Buffer {
         }
 
         Self {
-            owner_window: owner,
             dc,
             bitmap,
             width,
@@ -147,7 +136,7 @@ impl Buffer {
 
 /// The handle to a window for software buffering.
 pub struct Win32Impl<D: ?Sized, W> {
-    /// The window handle. We do not own this.
+    /// The window handle.
     window: HWND,
 
     /// The device context for the window.
@@ -165,6 +154,13 @@ pub struct Win32Impl<D: ?Sized, W> {
     ///
     /// We don't use this, but other code might.
     _display: PhantomData<D>,
+}
+
+impl<D: ?Sized, W> Drop for Win32Impl<D, W> {
+    fn drop(&mut self) {
+        // Release our resources.
+        Allocator::get().release(self.window, self.dc);
+    }
 }
 
 /// The Win32-compatible bitmap information.
@@ -214,23 +210,8 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
 
         // Get the handle to the device context.
         // SAFETY: We have confirmed that the window handle is valid.
-        // SAFETY: By the safety conditions for window_handle, this window is valid for
-        // this thread.
         let hwnd = handle.hwnd.get() as HWND;
-
-        // Add a subclass to this window that lets us perform some Windows operations
-        // on its original thread.
-        let result =
-            unsafe { Shell::SetWindowSubclass(hwnd, Some(handle_dc_subclass), SUBCLASS_ID, 0) };
-        if result == 0 {
-            return Err(SoftBufferError::PlatformError(
-                Some("Unable to set window subclass".into()),
-                Some(Box::new(io::Error::last_os_error())),
-            )
-            .into());
-        }
-
-        let dc = unsafe { Gdi::GetDC(hwnd) };
+        let dc = Allocator::get().get_dc(hwnd);
 
         // GetDC returns null if there is a platform error.
         if dc == 0 {
@@ -269,7 +250,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
             }
         }
 
-        self.buffer = Some(Buffer::new(self.window, self.dc, width, height));
+        self.buffer = Some(Buffer::new(self.dc, width, height));
 
         Ok(())
     }
@@ -285,15 +266,6 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
     /// Fetch the buffer from the window.
     fn fetch(&mut self) -> Result<Vec<u32>, SoftBufferError> {
         Err(SoftBufferError::Unimplemented)
-    }
-}
-
-impl<D: ?Sized, W> Drop for Win32Impl<D, W> {
-    fn drop(&mut self) {
-        // Remove the subclass from the window on its origin thread.
-        unsafe {
-            Win::PostMessageW(self.window, remove_subclass(), 0, self.dc);
-        }
     }
 }
 
@@ -335,103 +307,138 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
     }
 }
 
-/// Window procedure for our custom subclass.
-unsafe extern "system" fn handle_dc_subclass(
-    hwnd: HWND,
-    umsg: u32,
-    wparam: usize,
-    lparam: isize,
-    _subclass_id: usize,
-    _subclass_data: usize,
-) -> isize {
-    abort_on_panic(move || {
-        if umsg == get_compatible_dc() {
-            // Get a DC.
-            unsafe { Gdi::CreateCompatibleDC(lparam) }
-        } else if umsg == destroy_dc_and_bitmap() {
-            // Destroy the DC and bitmap for this window.
-            unsafe {
-                Gdi::DeleteDC(wparam as isize);
-                Gdi::DeleteObject(lparam);
-            }
-
-            0
-        } else if umsg == remove_subclass() {
-            // Release the existing DC.
-            unsafe {
-                Gdi::ReleaseDC(hwnd, lparam);
-            }
-
-            // Remove the subclass from the window.
-            unsafe {
-                Shell::RemoveWindowSubclass(hwnd, Some(handle_dc_subclass), SUBCLASS_ID);
-            }
-
-            0
-        } else {
-            // This isn't one of our custom messages. Forward to the underlying class.
-            unsafe { Shell::DefSubclassProc(hwnd, umsg, wparam, lparam) }
-        }
-    })
+/// Allocator for device contexts.
+///
+/// Device contexts can only be allocated or freed on the thread that originated them.
+/// So we spawn a thread specifically for allocating and freeing device contexts.
+/// This is the interface to that thread.
+struct Allocator {
+    /// The channel for sending commands.
+    sender: mpsc::Sender<Command>,
 }
 
-macro_rules! static_message {
-    ($(#[$attr:meta])* $name:ident) => {
-        $(#[$attr])*
-        fn $name() -> u32 {
-            static MESSAGE: AtomicU32 = AtomicU32::new(0);
-            const MESSAGE_NAME: &str = concat!(
-                "softbuffer_", env!("CARGO_PKG_VERSION"), "_", stringify!($name)
-            );
+impl Allocator {
+    /// Get the global instance of the allocator.
+    fn get() -> &'static Allocator {
+        static ALLOCATOR: OnceLock<Allocator> = OnceLock::new();
+        ALLOCATOR.get_or_init(|| {
+            let (sender, receiver) = mpsc::channel::<Command>();
 
-            let mut result = MESSAGE.load(Ordering::Relaxed);
+            // Create a thread responsible for DC handling.
+            thread::Builder::new()
+                .name(concat!("softbuffer_", env!("CARGO_PKG_VERSION"), "_dc_allocator").into())
+                .spawn(move || {
+                    while let Ok(command) = receiver.recv() {
+                        command.handle();
+                    }
+                })
+                .expect("failed to spawn the DC allocator thread");
 
-            if result == 0 {
-                // Register the window message, then store it.
-                let message = MESSAGE_NAME.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
-                result = unsafe {
-                    Win::RegisterWindowMessageW(message.as_ptr())
-                };
-                MESSAGE.store(result, Ordering::SeqCst);
-            }
+            Allocator { sender }
+        })
+    }
 
-            result
-        }
+    /// Get the device context for a window.
+    fn get_dc(&self, window: HWND) -> Gdi::HDC {
+        let (callback, waiter) = mpsc::sync_channel(1);
+
+        // Send command to the allocator.
+        self.sender
+            .send(Command::GetDc { window, callback })
+            .unwrap();
+
+        // Wait for the response back.
+        waiter.recv().unwrap()
+    }
+
+    /// Allocate a new device context.
+    fn allocate(&self, dc: Gdi::HDC) -> Gdi::HDC {
+        let (callback, waiter) = mpsc::sync_channel(1);
+
+        // Send command to the allocator.
+        self.sender
+            .send(Command::Allocate { dc, callback })
+            .unwrap();
+
+        // Wait for the response back.
+        waiter.recv().unwrap()
+    }
+
+    /// Deallocate a device context.
+    fn deallocate(&self, dc: Gdi::HDC) {
+        self.sender.send(Command::Deallocate(dc)).ok();
+    }
+
+    /// Release a device context.
+    fn release(&self, owner: HWND, dc: Gdi::HDC) {
+        self.sender.send(Command::Release { dc, owner }).ok();
     }
 }
 
-static_message! {
-    /// Get the compatible DC for an existing DC.
-    ///
-    /// lparam is the DC. The returned value is the DC.
-    get_compatible_dc
+/// Commands to be sent to the allocator.
+enum Command {
+    /// Call `GetDc` to get the device context for the provided window.
+    GetDc {
+        /// The window to provide a device context for.
+        window: HWND,
+
+        /// Send back the device context.
+        callback: mpsc::SyncSender<Gdi::HDC>,
+    },
+
+    /// Allocate a new device context using `GetCompatibleDc`.
+    Allocate {
+        /// The DC to be compatible with.
+        dc: Gdi::HDC,
+
+        /// Send back the device context.
+        callback: mpsc::SyncSender<Gdi::HDC>,
+    },
+
+    /// Deallocate a device context.
+    Deallocate(Gdi::HDC),
+
+    /// Release a window-associated device context.
+    Release {
+        /// The device context to release.
+        dc: Gdi::HDC,
+
+        /// The window that owns this device context.
+        owner: HWND,
+    },
 }
 
-static_message! {
-    /// Destroy a DC and a bitmap for this window.
+impl Command {
+    /// Handle this command.
     ///
-    /// wparam is the DC, lparam is the bitmap.
-    destroy_dc_and_bitmap
-}
+    /// This should be called on the allocator thread.
+    fn handle(self) {
+        match self {
+            Self::GetDc { window, callback } => {
+                // Get the DC and send it back.
+                let dc = unsafe { Gdi::GetDC(window) };
+                callback.send(dc).ok();
+            }
 
-static_message! {
-    /// Remove our subclass and release our DC.
-    ///
-    /// lparam is the DC.
-    remove_subclass
-}
+            Self::Allocate { dc, callback } => {
+                // Allocate a DC and send it back.
+                let dc = unsafe { Gdi::CreateCompatibleDC(dc) };
+                callback.send(dc).ok();
+            }
 
-fn abort_on_panic<R>(f: impl FnOnce() -> R) -> R {
-    struct AbortOnDrop;
+            Self::Deallocate(dc) => {
+                // Deallocate this DC.
+                unsafe {
+                    Gdi::DeleteDC(dc);
+                }
+            }
 
-    impl Drop for AbortOnDrop {
-        fn drop(&mut self) {
-            std::process::abort();
+            Self::Release { dc, owner } => {
+                // Release thie DC.
+                unsafe {
+                    Gdi::ReleaseDC(owner, dc);
+                }
+            }
         }
     }
-
-    let bomb = AbortOnDrop;
-    let data = f();
-    core::mem::forget(bomb);
-    data
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ fn display_handle_type_name(handle: &RawDisplayHandle) -> &'static str {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), not(target_arch = "wasm64")))]
+#[cfg(not(target_family = "wasm"))]
 fn __assert_send() {
     fn is_send<T: Send>() {}
     fn is_sync<T: Sync>() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,17 @@ pub struct Context<D> {
     context_impl: ContextDispatch<D>,
 
     /// This is Send+Sync IFF D is Send+Sync.
-    _marker: PhantomData<Arc<D>>
+    _marker: PhantomData<Arc<D>>,
 }
 
 impl<D: HasDisplayHandle> Context<D> {
     /// Creates a new instance of this struct, using the provided display.
     pub fn new(display: D) -> Result<Self, SoftBufferError> {
         match ContextDispatch::new(display) {
-            Ok(context_impl) => Ok(Self { context_impl, _marker: PhantomData }),
+            Ok(context_impl) => Ok(Self {
+                context_impl,
+                _marker: PhantomData,
+            }),
             Err(InitError::Unsupported(display)) => {
                 let raw = display.display_handle()?.as_raw();
                 Err(SoftBufferError::UnsupportedDisplayPlatform {

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,8 @@ pub struct BorrowStack<'a, T: 'a + ?Sized, U: 'a + ?Sized> {
     _phantom: std::marker::PhantomData<&'a mut T>,
 }
 
+unsafe impl<'a, T: 'a + Send + ?Sized, U: 'a + Send + ?Sized> Send for BorrowStack<'a, T, U> {}
+
 impl<'a, T: 'a + ?Sized, U: 'a + ?Sized> BorrowStack<'a, T, U> {
     pub fn new<F>(container: &'a mut T, f: F) -> Result<Self, SoftBufferError>
     where


### PR DESCRIPTION
Previously, types in softbuffer were !Send and !Sync. However it would
be nice if types could be shared across threads. Therefore I've made the
following changes:

- Context<D> is Send+Sync iff D is Send+Sync
- Surface<D, W> is Send iff D is Send+Sync and W is Send
- Buffer<'x, D, W> is Send iff D if Send+Sync and W is Send

Materially, I've made the following changes across the backends:

- X11, Wayland and KMS use Arc for their displays instead of Rc.
- MacOS uses MainThreadBound to secure windowing resources. This
  restriction was already implicitly enforced anyhow.
- Windows creates a thread specifically for allocating and then deallocating device contexts. This lets us get around the thread affinity problem.
- Web just isn't `Send`.

Closes #205, still WIP
