### PR TITLE
v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
-- Bump MSRV to 1.70.0.
+# 0.4.3
+
+- Use objc2 as the backend for the CoreGraphics implementation. (#210)
+- Update drm-rs to version v0.12.0. (#209)
+- Bump MSRV to 1.70.0 to be in line with Winit.
 
 # 0.4.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"


### PR DESCRIPTION
- Use objc2 as the backend for the CoreGraphics implementation. (#210)
- Update drm-rs to version v0.12.0. (#209)
- Bump MSRV to 1.70.0 to be in line with Winit.
