### PR TITLE
v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.4.5
+
+- Make the `wayland-sys` dependency optional. (#223)
+- Allow for transparent visuals on X11. This technically doesn't work, but
+  otherwise `winit` users might get crashes. (#226)
+
 # 0.4.4
 
 - Make `Context` `Send`+`Sync` and `Surface` `Send`. (#217)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"


### PR DESCRIPTION
- Make the `wayland-sys` dependency optional. (#223)
- Allow for transparent visuals on X11. This technically doesn't work, but
  otherwise `winit` users might get crashes. (#226)