### PR TITLE
examples: Make `utils/winit_app.rs` a `path`-referenced module again to fix autoformatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::Window;
 
-include!("../examples/utils/winit_app.rs");
+#[path = "../examples/utils/winit_app.rs"]
+mod winit_app;
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -7,7 +7,8 @@ use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 
-include!("./utils/winit_app.rs");
+#[path = "utils/winit_app.rs"]
+mod winit_app;
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -4,7 +4,8 @@ use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 
-include!("utils/winit_app.rs");
+#[path = "utils/winit_app.rs"]
+mod winit_app;
 
 fn main() {
     //see fruit.jpg.license for the license of fruit.jpg

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -3,7 +3,8 @@ use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 
-include!("utils/winit_app.rs");
+#[path = "utils/winit_app.rs"]
+mod winit_app;
 
 fn redraw(buffer: &mut [u32], width: usize, height: usize, flag: bool) {
     for y in 0..height {

--- a/examples/utils/winit_app.rs
+++ b/examples/utils/winit_app.rs
@@ -1,122 +1,121 @@
 /// Common boilerplate for setting up a winit application.
-mod winit_app {
-    use std::marker::PhantomData;
-    use std::rc::Rc;
+use std::marker::PhantomData;
+use std::rc::Rc;
 
-    use winit::application::ApplicationHandler;
-    use winit::event::{Event, WindowEvent};
-    use winit::event_loop::{EventLoop, ActiveEventLoop};
-    use winit::window::{WindowAttributes, WindowId, Window};
+use winit::application::ApplicationHandler;
+use winit::event::{Event, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::window::{Window, WindowAttributes, WindowId};
 
-    /// Run a Winit application.
-    #[allow(unused_mut)]
-    pub(crate) fn run_app(event_loop: EventLoop<()>, mut app: impl ApplicationHandler<()> + 'static) {
-        #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
-        event_loop.run_app(&mut app).unwrap();
+/// Run a Winit application.
+#[allow(unused_mut)]
+pub(crate) fn run_app(event_loop: EventLoop<()>, mut app: impl ApplicationHandler<()> + 'static) {
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+    event_loop.run_app(&mut app).unwrap();
 
-        #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
-        winit::platform::web::EventLoopExtWebSys::spawn_app(event_loop, app);
+    #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+    winit::platform::web::EventLoopExtWebSys::spawn_app(event_loop, app);
+}
+
+/// Create a window from a set of window attributes.
+#[allow(dead_code)]
+pub(crate) fn make_window(
+    elwt: &ActiveEventLoop,
+    f: impl FnOnce(WindowAttributes) -> WindowAttributes,
+) -> Rc<Window> {
+    let attributes = f(WindowAttributes::default());
+    #[cfg(target_arch = "wasm32")]
+    let attributes = winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
+    let window = elwt.create_window(attributes);
+    Rc::new(window.unwrap())
+}
+
+/// Easily constructable winit application.
+pub(crate) struct WinitApp<T, Init, Handler> {
+    /// Closure to initialize state.
+    init: Init,
+
+    /// Closure to run on window events.
+    event: Handler,
+
+    /// Contained state.
+    state: Option<T>,
+}
+
+/// Builder that makes it so we don't have to name `T`.
+pub(crate) struct WinitAppBuilder<T, Init> {
+    /// Closure to initialize state.
+    init: Init,
+
+    /// Eat the type parameter.
+    _marker: PhantomData<Option<T>>,
+}
+
+impl<T, Init> WinitAppBuilder<T, Init>
+where
+    Init: FnMut(&ActiveEventLoop) -> T,
+{
+    /// Create with an "init" closure.
+    pub(crate) fn with_init(init: Init) -> Self {
+        Self {
+            init,
+            _marker: PhantomData,
+        }
     }
 
-    /// Create a window from a set of window attributes.
-    #[allow(dead_code)]
-    pub(crate) fn make_window(elwt: &ActiveEventLoop, f: impl FnOnce(WindowAttributes) -> WindowAttributes) -> Rc<Window> {
-        let attributes = f(WindowAttributes::default());
-        #[cfg(target_arch = "wasm32")]
-        let attributes = winit::platform::web::WindowAttributesExtWebSys::with_append(
-            attributes,
-            true
-        );
-        let window = elwt.create_window(attributes);
-        Rc::new(window.unwrap())
-    }
-
-    /// Easily constructable winit application.
-    pub(crate) struct WinitApp<T, Init, Handler> {
-        /// Closure to initialize state.
-        init: Init,
-
-        /// Closure to run on window events.
-        event: Handler,
-
-        /// Contained state.
-        state: Option<T>
-    }
-
-    /// Builder that makes it so we don't have to name `T`.
-    pub(crate) struct WinitAppBuilder<T, Init> {
-        /// Closure to initialize state.
-        init: Init,
-
-        /// Eat the type parameter.
-        _marker: PhantomData<Option<T>>,
-    }
-
-    impl<T, Init> WinitAppBuilder<T, Init>
-    where Init: FnMut(&ActiveEventLoop) -> T,
+    /// Build a new application.
+    pub(crate) fn with_event_handler<F>(self, handler: F) -> WinitApp<T, Init, F>
+    where
+        F: FnMut(&mut T, Event<()>, &ActiveEventLoop),
     {
-        /// Create with an "init" closure.
-        pub(crate) fn with_init(init: Init) -> Self {
-            Self {
-                init,
-                _marker: PhantomData
-            }
-        }
+        WinitApp::new(self.init, handler)
+    }
+}
 
-        /// Build a new application.
-        pub(crate) fn with_event_handler<F>(self, handler: F) -> WinitApp<T, Init, F>
-        where F: FnMut(&mut T, Event<()>, &ActiveEventLoop)
-        {
-            WinitApp::new(self.init, handler)
+impl<T, Init, Handler> WinitApp<T, Init, Handler>
+where
+    Init: FnMut(&ActiveEventLoop) -> T,
+    Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop),
+{
+    /// Create a new application.
+    pub(crate) fn new(init: Init, event: Handler) -> Self {
+        Self {
+            init,
+            event,
+            state: None,
         }
     }
+}
 
-    impl<T, Init, Handler> WinitApp<T, Init, Handler>
-    where Init: FnMut(&ActiveEventLoop) -> T,
-          Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop)
-    {
-        /// Create a new application.
-        pub(crate) fn new(init: Init, event: Handler) -> Self {
-            Self {
-                init,
-                event,
-                state: None
-            }
-        }
+impl<T, Init, Handler> ApplicationHandler for WinitApp<T, Init, Handler>
+where
+    Init: FnMut(&ActiveEventLoop) -> T,
+    Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop),
+{
+    fn resumed(&mut self, el: &ActiveEventLoop) {
+        debug_assert!(self.state.is_none());
+        self.state = Some((self.init)(el));
     }
 
-    impl<T, Init, Handler> ApplicationHandler for WinitApp<T, Init, Handler>
-    where Init: FnMut(&ActiveEventLoop) -> T,
-          Handler: FnMut(&mut T, Event<()>, &ActiveEventLoop) {
+    fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
+        let state = self.state.take();
+        debug_assert!(state.is_some());
+        drop(state);
+    }
 
-        fn resumed(&mut self, el: &ActiveEventLoop) {
-            debug_assert!(self.state.is_none());
-            self.state = Some((self.init)(el));
-        }
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let state = self.state.as_mut().unwrap();
+        (self.event)(state, Event::WindowEvent { window_id, event }, event_loop);
+    }
 
-        fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
-            let state = self.state.take();
-            debug_assert!(state.is_some());
-            drop(state);
-        }
-
-        fn window_event(
-            &mut self,
-            event_loop: &ActiveEventLoop,
-            window_id: WindowId,
-            event: WindowEvent,
-        ) {
-            let state = self.state.as_mut().unwrap();
-            (self.event)(state, Event::WindowEvent {
-                window_id,
-                event
-            }, event_loop);
-        }
-
-        fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-            if let Some(state) = self.state.as_mut() {
-                (self.event)(state, Event::AboutToWait, event_loop);
-            }
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if let Some(state) = self.state.as_mut() {
+            (self.event)(state, Event::AboutToWait, event_loop);
         }
     }
 }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -3,7 +3,8 @@ use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 
-include!("utils/winit_app.rs");
+#[path = "utils/winit_app.rs"]
+mod winit_app;
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -1,6 +1,10 @@
 //! `Surface` implements `Send`. This makes sure that multithreading can work here.
 
 #[cfg(not(target_family = "wasm"))]
+#[path = "utils/winit_app.rs"]
+mod winit_app;
+
+#[cfg(not(target_family = "wasm"))]
 mod ex {
     use std::num::NonZeroU32;
     use std::sync::{mpsc, Arc, Mutex};
@@ -9,7 +13,7 @@ mod ex {
     use winit::keyboard::{Key, NamedKey};
     use winit::window::Window;
 
-    include!("utils/winit_app.rs");
+    use super::winit_app;
 
     type Surface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
 

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -3,7 +3,8 @@ use winit::event::{Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 
-include!("utils/winit_app.rs");
+#[path = "utils/winit_app.rs"]
+mod winit_app;
 
 const BUFFER_WIDTH: usize = 256;
 const BUFFER_HEIGHT: usize = 128;


### PR DESCRIPTION
Via `include!()` `rustfmt` doesn't know that this file belongs to the current project and doesn't autoformat it. Furthermore, jump-to-symbol likely doesn't play that well with `include!()`.

Without creating a `lib.rs` file in `utils/`, use `#[path]` to reference the existing file without following a `mod`ule hierarchy.

Note that the file remains in the `utils/` folder as that doesn't get picked up by `autoexamples`.
