### PR TITLE
Add a MSRV policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           - { target: x86_64-unknown-netbsd,    os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen,wayland,wayland-dlopen"  }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
+        exclude:
+          # Orbital doesn't follow MSRV
+          - rust_version: '1.70.0'
+            platform: { target: x86_64-unknown-redox, os: ubuntu-latest }
         include:
           - rust_version: nightly
             platform: { target: wasm32-unknown-unknown, os: ubuntu-latest, options: "-Zbuild-std=panic_abort,std", rustflags: "-Ctarget-feature=+atomics,+bulk-memory" }
@@ -90,7 +94,6 @@ jobs:
       run: |
         cargo update -p ahash --precise 0.8.7
         cargo update -p bumpalo --precise 3.14.0
-        cargo update -p redox_syscall@0.5.3 --precise 0.5.2
 
     - name: Build crate
       shell: bash

--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ fn main() {
 }
 ```
 
+MSRV Policy
+==
+This crate's Minimum Supported Rust Version (MSRV) is **1.70**. Changes to
+the MSRV will be accompanied by a minor version bump.
+
+As a **tentative** policy, the upper bound of the MSRV is given by the following
+formula:
+
+```text
+min(sid, stable - 3)
+```
+
+Where `sid` is the current version of `rustc` provided by [Debian Sid], and
+`stable` is the latest stable version of Rust. This bound may be broken in case of a major ecosystem shift or a security vulnerability.
+
+[Debian Sid]: https://packages.debian.org/sid/rustc
+
+Orbital is not covered by this MSRV policy, as it requires a Rust nightly
+toolchain to compile.
+
+All crates in the [`rust-windowing`] organizations have the
+same MSRV policy.
+
+[`rust-windowing`]: https://github.com/rust-windowing
+
 Changelog
 ---------
 


### PR DESCRIPTION
This MSRV policy is copied from Winit.
Orbital is excluded from it because it requires nightly to begin with.

As discussed in https://github.com/rust-windowing/softbuffer/pull/228#discussion_r1686692401.