### PR TITLE
`NoDisplayHandle` is unused by some backends

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,7 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> ops::DerefMut for Buffer<'a, D
 
 /// There is no display handle.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct NoDisplayHandle(core::convert::Infallible);
 
 impl HasDisplayHandle for NoDisplayHandle {


### PR DESCRIPTION
This was detected by the latest nightly Rust compiler, which broke our CI.