### PR TITLE
Resize the surface at the correct time in examples

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -33,12 +33,22 @@ fn main() {
         match event {
             Event::WindowEvent {
                 window_id,
+                event: WindowEvent::Resized(size),
+            } if window_id == window.id() => {
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+                {
+                    surface.resize(width, height).unwrap();
+                }
+            }
+            Event::WindowEvent {
+                window_id,
                 event: WindowEvent::RedrawRequested,
             } if window_id == window.id() => {
-                if let (Some(width), Some(height)) = {
-                    let size = window.inner_size();
-                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-                } {
+                let size = window.inner_size();
+                if let (Some(width), Some(height)) =
+                    { (NonZeroU32::new(size.width), NonZeroU32::new(size.height)) }
+                {
                     let elapsed = start.elapsed().as_secs_f64() % 1.0;
 
                     if (width.get(), height.get()) != *old_size {
@@ -48,7 +58,6 @@ fn main() {
 
                     let frame = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
 
-                    surface.resize(width, height).unwrap();
                     let mut buffer = surface.buffer_mut().unwrap();
                     buffer.copy_from_slice(frame);
                     buffer.present().unwrap();

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -47,7 +47,7 @@ fn main() {
             } if window_id == window.id() => {
                 let size = window.inner_size();
                 if let (Some(width), Some(height)) =
-                    { (NonZeroU32::new(size.width), NonZeroU32::new(size.height)) }
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
                 {
                     let elapsed = start.elapsed().as_secs_f64() % 1.0;
 

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -23,7 +23,8 @@ fn main() {
         let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
 
         // Intentionally only set the size of the surface once, at creation.
-        // This is needed if the window chooses to ignore the size we passed in above.
+        // This is needed if the window chooses to ignore the size we passed in above, and for the
+        // platforms softbuffer supports that don't yet extract the size from the window.
         surface
             .resize(
                 NonZeroU32::new(width).unwrap(),

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -20,7 +20,16 @@ fn main() {
         });
 
         let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        // Intentionally only set the size of the surface once, at creation.
+        // This is needed if the window chooses to ignore the size we passed in above.
+        surface
+            .resize(
+                NonZeroU32::new(width).unwrap(),
+                NonZeroU32::new(height).unwrap(),
+            )
+            .unwrap();
 
         (window, surface)
     })
@@ -33,13 +42,6 @@ fn main() {
                 window_id,
                 event: WindowEvent::RedrawRequested,
             } if window_id == window.id() => {
-                surface
-                    .resize(
-                        NonZeroU32::new(fruit.width()).unwrap(),
-                        NonZeroU32::new(fruit.height()).unwrap(),
-                    )
-                    .unwrap();
-
                 let mut buffer = surface.buffer_mut().unwrap();
                 let width = fruit.width() as usize;
                 for (x, y, pixel) in fruit.pixels() {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -45,16 +45,24 @@ fn main() {
         match event {
             Event::WindowEvent {
                 window_id,
+                event: WindowEvent::Resized(size),
+            } if window_id == window.id() => {
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+                {
+                    // Resize surface
+                    surface.resize(width, height).unwrap();
+                }
+            }
+            Event::WindowEvent {
+                window_id,
                 event: WindowEvent::RedrawRequested,
             } if window_id == window.id() => {
-                // Grab the window's client area dimensions
-                if let (Some(width), Some(height)) = {
-                    let size = window.inner_size();
+                // Grab the window's client area dimensions, and ensure they're valid
+                let size = window.inner_size();
+                if let (Some(width), Some(height)) =
                     (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-                } {
-                    // Resize surface if needed
-                    surface.resize(width, height).unwrap();
-
+                {
                     // Draw something in the window
                     let mut buffer = surface.buffer_mut().unwrap();
                     redraw(

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -24,14 +24,22 @@ fn main() {
         match event {
             Event::WindowEvent {
                 window_id,
+                event: WindowEvent::Resized(size),
+            } if window_id == window.id() => {
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+                {
+                    surface.resize(width, height).unwrap();
+                }
+            }
+            Event::WindowEvent {
+                window_id,
                 event: WindowEvent::RedrawRequested,
             } if window_id == window.id() => {
-                if let (Some(width), Some(height)) = {
-                    let size = window.inner_size();
+                let size = window.inner_size();
+                if let (Some(width), Some(height)) =
                     (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-                } {
-                    surface.resize(width, height).unwrap();
-
+                {
                     let mut buffer = surface.buffer_mut().unwrap();
                     for y in 0..height.get() {
                         for x in 0..width.get() {

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -16,7 +16,15 @@ fn main() {
         let window = winit_app::make_window(elwt, |w| w);
 
         let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        // Intentionally set the size of the surface to something different than the size of the window.
+        surface
+            .resize(
+                NonZeroU32::new(BUFFER_WIDTH as u32).unwrap(),
+                NonZeroU32::new(BUFFER_HEIGHT as u32).unwrap(),
+            )
+            .unwrap();
 
         (window, surface)
     })
@@ -29,13 +37,6 @@ fn main() {
                 window_id,
                 event: WindowEvent::RedrawRequested,
             } if window_id == window.id() => {
-                surface
-                    .resize(
-                        NonZeroU32::new(BUFFER_WIDTH as u32).unwrap(),
-                        NonZeroU32::new(BUFFER_HEIGHT as u32).unwrap(),
-                    )
-                    .unwrap();
-
                 let mut buffer = surface.buffer_mut().unwrap();
                 for y in 0..BUFFER_HEIGHT {
                     for x in 0..BUFFER_WIDTH {


### PR DESCRIPTION
The examples previously showed resizing just before rendering, which is inefficient, the user should only resize when needed. Tested on macOS.

I have not updated the `winit_multithread` example, as it was a bit more cumbersome, and I wouldn't be able to test it anyways, as it doesn't seem to work on macOS.