### PR TITLE
WIP: Format API / Transparency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,19 @@ name = "buffer_mut"
 harness = false
 
 [features]
-default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen"]
+default = ["kms", "x11", "x11-dlopen", "wayland", "wayland-dlopen","compatibility"]
 kms = ["bytemuck", "drm", "rustix"]
 wayland = ["wayland-backend", "wayland-client", "wayland-sys", "memmap2", "rustix", "fastrand"]
 wayland-dlopen = ["wayland-sys/dlopen"]
 x11 = ["as-raw-xcb-connection", "bytemuck", "fastrand", "rustix", "tiny-xlib", "x11rb"]
 x11-dlopen = ["tiny-xlib/dlopen", "x11rb/dl-libxcb"]
+compatibility = []
 
 [dependencies]
 log = "0.4.17"
 raw_window_handle = { package = "raw-window-handle", version = "0.6", features = ["std"] }
+num = "0.4.3"
+duplicate = "1.0.0"
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "android", target_os = "redox"))))'.dependencies]
 as-raw-xcb-connection = { version = "1.0.0", optional = true }
@@ -43,7 +46,7 @@ x11rb = { version = "0.13.0", features = ["allow-unsafe-code", "shm"], optional 
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.59.0"
-features = ["Win32_Graphics_Gdi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Win32_Foundation"]
+features = ["Win32_Graphics_Gdi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_UI_ColorSystem"]
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 bytemuck = { version = "1.12.3", features = ["extern_crate_alloc"] }

--- a/benches/buffer_mut.rs
+++ b/benches/buffer_mut.rs
@@ -53,7 +53,7 @@ fn buffer_mut(c: &mut Criterion) {
                     let mut buffer = surface.buffer_mut().unwrap();
                     b.iter(|| {
                         for _ in 0..500 {
-                            let x: &mut [u32] = &mut buffer;
+                            let x: &mut [u32] = &mut buffer.pixels_mut();
                             black_box(x);
                         }
                     });

--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -1,16 +1,17 @@
 //! Implements `buffer_interface::*` traits for enums dispatching to backends
 
-use crate::{backend_interface::*, backends, InitError, Rect, SoftBufferError};
+use crate::{backend_interface::*, backends, InitError, Rect, SoftBufferError, BufferReturn, WithAlpha, WithoutAlpha};
 
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use duplicate::duplicate_item;
 use std::num::NonZeroU32;
 #[cfg(any(wayland_platform, x11_platform, kms_platform))]
 use std::sync::Arc;
 
 /// A macro for creating the enum used to statically dispatch to the platform-specific implementation.
-macro_rules! make_dispatch {
+macro_rules! make_enum {
     (
-        <$dgen: ident, $wgen: ident> =>
+        <$dgen: ident, $wgen: ident, $alpha: ident> =>
         $(
             $(#[$attr:meta])*
             $name: ident
@@ -21,6 +22,21 @@ macro_rules! make_dispatch {
             $(
                 $(#[$attr])*
                 $name($context_inner),
+            )*
+        }
+
+        #[allow(clippy::large_enum_variant)] // it's boxed anyways
+        pub(crate) enum SurfaceDispatch<$dgen, $wgen, $alpha> {
+            $(
+                $(#[$attr])*
+                $name($surface_inner),
+            )*
+        }
+
+        pub(crate) enum BufferDispatch<'a, $dgen, $wgen, $alpha> {
+            $(
+                $(#[$attr])*
+                $name($buffer_inner),
             )*
         }
 
@@ -54,18 +70,21 @@ macro_rules! make_dispatch {
                 Err(InitError::Unsupported(display))
             }
         }
+    };
+}
 
-        #[allow(clippy::large_enum_variant)] // it's boxed anyways
-        pub(crate) enum SurfaceDispatch<$dgen, $wgen> {
-            $(
-                $(#[$attr])*
-                $name($surface_inner),
-            )*
-        }
-
-        impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for SurfaceDispatch<D, W> {
+macro_rules! make_dispatch {
+    (
+        <$dgen: ident, $wgen: ident, $alpha: ident> =>
+        $(
+            $(#[$attr:meta])*
+            $name: ident
+            ($context_inner: ty, $surface_inner: ty, $buffer_inner: ty),
+        )*
+    ) => {
+        impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W, $alpha> for SurfaceDispatch<D, W, $alpha>{
             type Context = ContextDispatch<D>;
-            type Buffer<'a> = BufferDispatch<'a, D, W> where Self: 'a;
+            type Buffer<'a> = BufferDispatch<'a, D, W, $alpha> where Self: 'a;
 
             fn new(window: W, display: &Self::Context) -> Result<Self, InitError<W>>
             where
@@ -75,6 +94,18 @@ macro_rules! make_dispatch {
                     $(
                         $(#[$attr])*
                         ContextDispatch::$name(inner) => Ok(Self::$name(<$surface_inner>::new(window, inner)?)),
+                    )*
+                }
+            }
+
+            fn new_with_alpha(window: W, display: &Self::Context) -> Result<Self, InitError<W>>
+            where
+                W: Sized,
+            Self: Sized {
+                match display {
+                    $(
+                        $(#[$attr])*
+                        ContextDispatch::$name(inner) => Ok(Self::$name(<$surface_inner>::new_with_alpha(window, inner)?)),
                     )*
                 }
             }
@@ -97,7 +128,7 @@ macro_rules! make_dispatch {
                 }
             }
 
-            fn buffer_mut(&mut self) -> Result<BufferDispatch<'_, D, W>, SoftBufferError> {
+            fn buffer_mut(&mut self) -> Result<BufferDispatch<'_, D, W, $alpha>, SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
@@ -116,14 +147,8 @@ macro_rules! make_dispatch {
             }
         }
 
-        pub(crate) enum BufferDispatch<'a, $dgen, $wgen> {
-            $(
-                $(#[$attr])*
-                $name($buffer_inner),
-            )*
-        }
-
-        impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferDispatch<'a, D, W> {
+        
+        impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface<$alpha> for BufferDispatch<'a, D, W, $alpha> {
             #[inline]
             fn pixels(&self) -> &[u32] {
                 match self {
@@ -140,6 +165,15 @@ macro_rules! make_dispatch {
                     $(
                         $(#[$attr])*
                         Self::$name(inner) => inner.pixels_mut(),
+                    )*
+                }
+            }
+
+            fn pixels_rgb_mut(&mut self) -> &mut[<$alpha as BufferReturn>::Output]{
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => inner.pixels_rgb_mut(),
                     )*
                 }
             }
@@ -176,8 +210,8 @@ macro_rules! make_dispatch {
 
 // XXX empty enum with generic bound is invalid?
 
-make_dispatch! {
-    <D, W> =>
+make_enum!{
+    <D, W, A> =>
     #[cfg(x11_platform)]
     X11(Arc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'a, D, W>),
     #[cfg(wayland_platform)]
@@ -185,9 +219,32 @@ make_dispatch! {
     #[cfg(kms_platform)]
     Kms(Arc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'a, D, W>),
     #[cfg(target_os = "windows")]
-    Win32(D, backends::win32::Win32Impl<D, W>, backends::win32::BufferImpl<'a, D, W>),
+    Win32(D, backends::win32::Win32Impl<D, W, A>, backends::win32::BufferImpl<'a, D, W, A>),
     #[cfg(target_vendor = "apple")]
-    CoreGraphics(D, backends::cg::CGImpl<D, W>, backends::cg::BufferImpl<'a, D, W>),
+    CoreGraphics(D, backends::cg::CGImpl<D, W, A>, backends::cg::BufferImpl<'a, D, W, A>),
+    #[cfg(target_arch = "wasm32")]
+    Web(backends::web::WebDisplayImpl<D>, backends::web::WebImpl<D, W>, backends::web::BufferImpl<'a, D, W>),
+    #[cfg(target_os = "redox")]
+    Orbital(D, backends::orbital::OrbitalImpl<D, W>, backends::orbital::BufferImpl<'a, D, W>),
+}
+
+#[duplicate_item(
+    TY;
+    [ WithAlpha ];
+    [ WithoutAlpha ];
+  )]
+make_dispatch! {
+    <D, W, TY> =>
+    #[cfg(x11_platform)]
+    X11(Arc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'a, D, W>),
+    #[cfg(wayland_platform)]
+    Wayland(Arc<backends::wayland::WaylandDisplayImpl<D>>, backends::wayland::WaylandImpl<D, W>, backends::wayland::BufferImpl<'a, D, W>),
+    #[cfg(kms_platform)]
+    Kms(Arc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'a, D, W>),
+    #[cfg(target_os = "windows")]
+    Win32(D, backends::win32::Win32Impl<D, W, TY>, backends::win32::BufferImpl<'a, D, W, TY>),
+    #[cfg(target_vendor = "apple")]
+    CoreGraphics(D, backends::cg::CGImpl<D, W, TY>, backends::cg::BufferImpl<'a, D, W, TY>),
     #[cfg(target_arch = "wasm32")]
     Web(backends::web::WebDisplayImpl<D>, backends::web::WebImpl<D, W>, backends::web::BufferImpl<'a, D, W>),
     #[cfg(target_os = "redox")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,9 @@ pub enum SoftBufferError {
     /// actual error type.
     PlatformError(Option<String>, Option<Box<dyn Error>>),
 
+    /// An Error returned from RGBX/RGBA::new() if called with numbers that are higher than u8::MAX
+    PrimitiveOutsideOfU8Range,
+
     /// This function is unimplemented on this platform.
     Unimplemented,
 }
@@ -138,6 +141,7 @@ impl fmt::Display for SoftBufferError {
                 "Damage rect {}x{} at ({}, {}) out of range for backend.",
                 rect.width, rect.height, rect.x, rect.y
             ),
+            Self::PrimitiveOutsideOfU8Range => write!(f, "The passed in primitive value is greater than what can fit in a u8"),
             Self::Unimplemented => write!(f, "This function is unimplemented on this platform."),
         }
     }


### PR DESCRIPTION
This is my answer to #17 and #98 

## WIP
I have only actually implemented the required changes for windows and mac os, as this was just an experiment to see if the idea I had would be doable. And those are the 2 platforms I have/use. 
If you are on these platforms feel free to point your cargo.toml at the fork to try it out. (If you do want to try it out, keep in mind you have to disable the ```compatibility``` feature in your cargo.toml that is enabled by default)

-----
## High level overview of changes:

- Added ability to tell backend that you want to use transparency/alpha channel
- Created RGBX/RGBA structs that can be used on every platform without needing to think about how the platform stores the u32 as the conversion to each of the platforms happens automatically

### Essentially the changes are as follows:
- Added softbuffer::Surface::new_with_alpha() function that creates an alpha aware surface
- Created ```RGBX``` and ```RGBA``` structs
  - Both structs have a ```Self::new()``` and  ```Self::new_unchecked()```
    - ```new()``` returns a result, with an error if any of the values passed in overflow a u8
    - ```new_unchecked()```returns ```Self``` directly, silently ignoring any overflow, the same as if you had ```300u32 as u8```
    - The two functions take any primitive number type (u8,u16,u32,etc)
    - I took a quick look at the machine code, when passing in a u8 or u32 it appears to be just as performant as doing bit shifts yourself (Obviously ```new``` has some extra jmp for the overflow checks but ```new_unchecked``` is very clean). In the case that you pass u8's into ```new``` it has the same machine code as ```new_unchecked```
    - The structs are ```#[Repr(C)]``` with 4 u8's in them. I then change the ordering of the r,g,b,x/a properties based on the platform, and then inside the bufferImpl I can transmute the ```[u32]``` to the appropriate type based on with/without alpha
- Depreciated old api where you get access to a raw ```&mut [u32]``` buffer
  - Added feature ```compatibility``` to allow the old deref to still point to ```&mut [u32]``` buffer, enabled by default.
  - Without ```compatibility``` feature enabled, buffer now derefs to a ```&mut [RGBX]``` when called on a surface created by calling ```Surface::new()``` and ```&mut [RGBA]``` when called on a surface created by calling ```Surface::new_with_alpha()```
  - Can call ```buffer.pixels_mut()``` function to access old style &mut [u32] even with ```compatibility``` feature disabled
- Changed the backend impl for windows and macos
  - Added new_with_alpha method
  - Made required changes to tell backend that we are using alpha channel if called with new api, but still run the old way otherwise

## Example:

Taking the winit.rs example and changing the following relevant lines shows how this works:
```rust
let window = winit_app::make_window(elwt, |w| w.with_transparent(true));

let context = softbuffer::Context::new(window.clone()).unwrap();
let surface = softbuffer::Surface::new_with_alpha(&context, window.clone()).unwrap();

(window, surface)
```

```rust
let mut buffer = surface.buffer_mut().unwrap();
for y in 0..height.get() {
    for x in 0..width.get() {
        let red = x % 255;
        let green = y % 255;
        let blue = (x * y) % 255;
        let alpha = x % 255;
        let index = y as usize * width.get() as usize + x as usize;
        // buffer[index] = blue | (green << 8) | (red << 16) | (alpha << 24); // <--- previous method
        buffer[index] = softbuffer::RGBA::new_unchecked(red, green, blue, alpha);

        //Using the RGBX type would not work, and would fail to compile as the rgb type is based on the surface constructor you called
        //buffer[index] = softbuffer::RGBX::new_unchecked(red, green, blue); // <-- Would fail to compile
    }
}
```

## Final Thoughts:

This was just some testing I wanted to do for my own project, if this is not the direction this project wants to go that is absolutely fine, I just thought I would share my experiments on the subject. I only spent about a day on it so no hard feelings if this never gets used.

The rest of the backends I did not update to even compile with the changes I made, so as is even if you just want to use the old api, this will not work on this branch currently.

If you did go this direction, you would probably want some extra conversion functions on the new RGBX/A types to be able to set them directly with a u32. (At least I think? Maybe not?) Of course that has the same issue of before of having conversion/format issues, but you could definitely implement it in such a way that there is either no conversion and it is platform dependent, or there is auto conversions for platforms that don't match the norm. Or a mix of both. 
You would also want to expose a ```buffer.pixels_rgb_mut()``` function just as a shim so that you can access the new methods while having the ```compatibility``` feature enabled, just to help the transition. 

Side Note: Please excuse the horror I created in the ```backend_dispatch.rs``` file. That could probably be cleaned up to be a bit nicer, I just wanted to get it working though. 

Thanks for coming to my Ted talk ❤️