### PR TITLE
examples/drm: Don't force `card{i}` enumeration to start at `0`

### DIFF
--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -168,12 +168,14 @@ mod imple {
         fn find() -> Result<Card, Box<dyn std::error::Error>> {
             for i in 0..10 {
                 let path = format!("/dev/dri/card{i}");
-                let device = Card::open(path)?;
+                // Card enumeration may not start at zero, allow failures while opening
+                let Ok(device) = Card::open(path) else {
+                    continue;
+                };
 
                 // Only use it if it has connectors.
-                let handles = match device.resource_handles() {
-                    Ok(handles) => handles,
-                    Err(_) => continue,
+                let Ok(handles) = device.resource_handles() else {
+                    continue;
                 };
 
                 if handles


### PR DESCRIPTION
On my setup with an AMD RX6800XT GPU (same happens with an Intel Arc GPU) there is only `card1` and `renderD128`.  The example would fail with a "File not found" error for `/dev/dri/card0` when it should instead continue to iterate to find the first valid DRM device.

A more future-proof solution would be to replace the `0..10` range with a `readdir()`-like iterator over the contents of `/dev/dri` if that's accepted for an example.  Note that `drm 0.14.0` added wrappers for dealing with `/dev/dri` files and https://github.com/Smithay/drm-rs/pull/208 is adding exactly the iterator we need to find the first valid device, which I'd recommend to use in our iterator instead when released :)
