### PR TITLE
Fix CI after Rust 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0 --deny warnings ${{ matrix.platform.rustflags }}"
-      OPTIONS: ${{ matrix.platform.options }}
+      # Disable doc tests on Rust 1.83
+      OPTIONS: ${{ matrix.platform.options }} ${{ matrix.rust_version == 'stable' && '--lib' || '' }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
       CMD: ${{ matrix.platform.cmd }}
       RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0 --deny warnings ${{ matrix.platform.rustflags }}"
-      # Disable doc tests on Rust 1.83
+      # Disable doc tests on Rust 1.83, since some path handling regressed there.
+      # This has been fixed in Rust 1.84 beta.
+      # https://github.com/rust-lang/rust/issues/132203
       OPTIONS: ${{ matrix.platform.options }} ${{ matrix.rust_version == 'stable' && '--lib' || '' }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
       CMD: ${{ matrix.platform.cmd }}

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -291,7 +291,7 @@ pub struct BufferImpl<'a, D, W> {
     buffer: Vec<u32>,
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'_, D, W> {
     #[inline]
     fn pixels(&self) -> &[u32] {
         &self.buffer

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -144,7 +144,10 @@ impl<D, W> Drop for CGImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<D, W> {
     type Context = D;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     fn new(window_src: W, _display: &D) -> Result<Self, InitError<W>> {
         // `NSView`/`UIView` can only be accessed from the main thread.

--- a/src/backends/kms.rs
+++ b/src/backends/kms.rs
@@ -194,7 +194,7 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
             .filter(|connector| {
                 connector
                     .current_encoder()
-                    .map_or(false, |encoder| encoders.contains(&encoder))
+                    .is_some_and(|encoder| encoders.contains(&encoder))
             })
             .map(|info| info.handle())
             .collect::<Vec<_>>();

--- a/src/backends/kms.rs
+++ b/src/backends/kms.rs
@@ -134,7 +134,10 @@ struct SharedBuffer {
 
 impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> for KmsImpl<D, W> {
     type Context = Arc<KmsDisplayImpl<D>>;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     /// Create a new KMS backend.
     fn new(window: W, display: &Arc<KmsDisplayImpl<D>>) -> Result<Self, InitError<W>> {

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -128,7 +128,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for OrbitalImpl<D, W> {
     type Context = D;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     fn new(window: W, _display: &D) -> Result<Self, InitError<W>> {
         let raw = window.window_handle()?.as_raw();

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -191,7 +191,7 @@ pub struct BufferImpl<'a, D, W> {
     pixels: Pixels,
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'_, D, W> {
     #[inline]
     fn pixels(&self) -> &[u32] {
         match &self.pixels {

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -41,7 +41,7 @@ impl OrbitalMap {
         unsafe { slice::from_raw_parts(self.address as *const u32, self.size_unaligned / 4) }
     }
 
-    unsafe fn data_mut(&self) -> &mut [u32] {
+    unsafe fn data_mut(&mut self) -> &mut [u32] {
         unsafe { slice::from_raw_parts_mut(self.address as *mut u32, self.size_unaligned / 4) }
     }
 }
@@ -99,7 +99,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
 
         {
             // Map window buffer
-            let window_map =
+            let mut window_map =
                 unsafe { OrbitalMap::new(self.window_fd(), window_width * window_height * 4) }
                     .expect("failed to map orbital window");
 

--- a/src/backends/wayland/mod.rs
+++ b/src/backends/wayland/mod.rs
@@ -264,9 +264,7 @@ pub struct BufferImpl<'a, D: ?Sized, W> {
     age: u8,
 }
 
-impl<'a, D: HasDisplayHandle + ?Sized, W: HasWindowHandle> BufferInterface
-    for BufferImpl<'a, D, W>
-{
+impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> BufferInterface for BufferImpl<'_, D, W> {
     #[inline]
     fn pixels(&self) -> &[u32] {
         self.stack.member()

--- a/src/backends/wayland/mod.rs
+++ b/src/backends/wayland/mod.rs
@@ -151,7 +151,10 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
     for WaylandImpl<D, W>
 {
     type Context = Arc<WaylandDisplayImpl<D>>;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     fn new(window: W, display: &Arc<WaylandDisplayImpl<D>>) -> Result<Self, InitError<W>> {
         // Get the raw Wayland window.

--- a/src/backends/web.rs
+++ b/src/backends/web.rs
@@ -377,7 +377,7 @@ pub struct BufferImpl<'a, D, W> {
     imp: &'a mut WebImpl<D, W>,
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'_, D, W> {
     fn pixels(&self) -> &[u32] {
         &self.imp.buffer
     }

--- a/src/backends/web.rs
+++ b/src/backends/web.rs
@@ -207,7 +207,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for WebImpl<D, W> {
     type Context = WebDisplayImpl<D>;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     fn new(window: W, display: &WebDisplayImpl<D>) -> Result<Self, InitError<W>> {
         let raw = window.window_handle()?.as_raw();

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -208,7 +208,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Win32Impl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Impl<D, W> {
     type Context = D;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     /// Create a new `Win32Impl` from a `Win32WindowHandle`.
     fn new(window: W, _display: &D) -> Result<Self, crate::error::InitError<W>> {

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -284,7 +284,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
 
 pub struct BufferImpl<'a, D, W>(&'a mut Win32Impl<D, W>);
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'_, D, W> {
     #[inline]
     fn pixels(&self) -> &[u32] {
         self.0.buffer.as_ref().unwrap().pixels()

--- a/src/backends/x11.rs
+++ b/src/backends/x11.rs
@@ -184,7 +184,10 @@ struct ShmBuffer {
 
 impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> for X11Impl<D, W> {
     type Context = Arc<X11DisplayImpl<D>>;
-    type Buffer<'a> = BufferImpl<'a, D, W> where Self: 'a;
+    type Buffer<'a>
+        = BufferImpl<'a, D, W>
+    where
+        Self: 'a;
 
     /// Create a new `X11Impl` from a `HasWindowHandle`.
     fn new(window_src: W, display: &Arc<X11DisplayImpl<D>>) -> Result<Self, InitError<W>> {

--- a/src/backends/x11.rs
+++ b/src/backends/x11.rs
@@ -387,8 +387,8 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
 
 pub struct BufferImpl<'a, D: ?Sized, W: ?Sized>(&'a mut X11Impl<D, W>);
 
-impl<'a, D: HasDisplayHandle + ?Sized, W: HasWindowHandle + ?Sized> BufferInterface
-    for BufferImpl<'a, D, W>
+impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle + ?Sized> BufferInterface
+    for BufferImpl<'_, D, W>
 {
     #[inline]
     fn pixels(&self) -> &[u32] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub struct Buffer<'a, D, W> {
     _marker: PhantomData<(Arc<D>, Cell<()>)>,
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> Buffer<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> Buffer<'_, D, W> {
     /// Is age is the number of frames ago this buffer was last presented. So if the value is
     /// `1`, it is the same as the last frame, and if it is `2`, it is the same as the frame
     /// before that (for backends using double buffering). If the value is `0`, it is a new
@@ -244,7 +244,7 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> Buffer<'a, D, W> {
     }
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> ops::Deref for Buffer<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> ops::Deref for Buffer<'_, D, W> {
     type Target = [u32];
 
     #[inline]
@@ -253,7 +253,7 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> ops::Deref for Buffer<'a, D, W
     }
 }
 
-impl<'a, D: HasDisplayHandle, W: HasWindowHandle> ops::DerefMut for Buffer<'a, D, W> {
+impl<D: HasDisplayHandle, W: HasWindowHandle> ops::DerefMut for Buffer<'_, D, W> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u32] {
         self.buffer_impl.pixels_mut()


### PR DESCRIPTION
The path changes that @MarijnS95 [outlined here](https://github.com/rust-windowing/softbuffer/pull/127#issuecomment-2400067577) seem to have been fixed in beta and in more recent nightlies, but did slip into the 1.83 release. So I've disabled doc tests on 1.83 in CI for now.