### PR TITLE
Fix examples by resizing the surface

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -18,7 +18,14 @@ fn main() {
         let window = winit_app::make_window(event_loop, |w| w);
 
         let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        surface
+            .resize(
+                NonZeroU32::new(window.inner_size().width).unwrap(),
+                NonZeroU32::new(window.inner_size().height).unwrap(),
+            )
+            .unwrap();
 
         let old_size = (0, 0);
         let frames = pre_render_frames(0, 0);

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -31,7 +31,14 @@ fn main() {
         });
 
         let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        surface
+            .resize(
+                NonZeroU32::new(window.inner_size().width).unwrap(),
+                NonZeroU32::new(window.inner_size().height).unwrap(),
+            )
+            .unwrap();
 
         let flag = false;
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -13,7 +13,14 @@ fn main() {
         let window = winit_app::make_window(elwt, |w| w);
 
         let context = softbuffer::Context::new(window.clone()).unwrap();
-        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+
+        surface
+            .resize(
+                NonZeroU32::new(window.inner_size().width).unwrap(),
+                NonZeroU32::new(window.inner_size().height).unwrap(),
+            )
+            .unwrap();
 
         (window, surface)
     })


### PR DESCRIPTION
When running some examples on my Linux system, I encountered an error:

```
index out of bounds: the len is 0 but the index is 0
```

This error occurred when attempting to perform array indexing write operations on the buffer generated by `surface.buffer_mut()`.

I successfully resolved these issues by resizing the surface during initialization.

