### PR TITLE
Appease clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       run: |
         cargo update -p ahash --precise 0.8.7
         cargo update -p bumpalo --precise 3.14.0
+        cargo update -p objc2-encode --precise 4.0.3
 
     - name: Build crate
       shell: bash

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -62,7 +62,7 @@ mod imple {
         let planes = planes
             .iter()
             .filter(|&&plane| {
-                device.get_plane(plane).map_or(false, |plane| {
+                device.get_plane(plane).is_ok_and(|plane| {
                     let crtcs = handles.filter_crtcs(plane.possible_crtcs());
                     crtcs.contains(&crtc.handle())
                 })
@@ -77,7 +77,7 @@ mod imple {
                     let (ids, vals) = props.as_props_and_values();
                     for (&id, &val) in ids.iter().zip(vals.iter()) {
                         if let Ok(info) = device.get_property(id) {
-                            if info.name().to_str().map_or(false, |x| x == "type") {
+                            if info.name().to_str() == Ok("type") {
                                 return val == PlaneType::Primary as u32 as u64;
                             }
                         }


### PR DESCRIPTION
Fixes DRM example failing in CI [here](https://github.com/rust-windowing/softbuffer/actions/runs/12953355212/job/36132854217?pr=254).

Also pins `objc2-encode` for the MSRV CI check (will be redundant after https://github.com/rust-windowing/softbuffer/pull/254).