### PR TITLE
fix transparency on macOS

### DIFF
--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -322,8 +322,8 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl<'_,
                 32,
                 self.imp.width * 4,
                 Some(&self.imp.color_space.0),
-                // TODO: This looks incorrect!
-                CGBitmapInfo::ByteOrder32Little | CGBitmapInfo(CGImageAlphaInfo::NoneSkipFirst.0),
+                CGBitmapInfo::ByteOrder32Little
+                    | CGBitmapInfo(CGImageAlphaInfo::PremultipliedFirst.0),
                 Some(&data_provider),
                 ptr::null(),
                 false,


### PR DESCRIPTION
https://developer.apple.com/documentation/coregraphics/cgimagealphainfo?language=objc

For supporting transparent windows on maOS this is all that is required. I've seen #241 which is adding alpha and it looks significantly more complicated. I might be missing why it is so complicated but this does work and I don't see why it should be any more complicated. I've tested it with tiny_skia. 

Using PremultipliedFirst instead of Last because that is consistent with the where the color channels are currently stored. 