### PR TITLE
Simplify usage of `Context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update to `objc2` 0.6.0.
 - Bump MSRV to Rust 1.71.
+- Make `Context` cloneable.
 
 # 0.4.6
 

--- a/README.md
+++ b/README.md
@@ -79,20 +79,16 @@ mod winit_app;
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
 
     let mut app = winit_app::WinitAppBuilder::with_init(
         |elwt| {
-            let window = {
-                let window = elwt.create_window(Window::default_attributes());
-                Rc::new(window.unwrap())
-            };
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
-            (window, context)
+            let window = elwt.create_window(Window::default_attributes());
+            Rc::new(window.unwrap())
         },
-        |_elwt, (window, context)| softbuffer::Surface::new(context, window.clone()).unwrap(),
+        |_elwt, window| softbuffer::Surface::new(&context, window.clone()).unwrap(),
     )
-    .with_event_handler(|(window, _context), surface, event, elwt| {
+    .with_event_handler(|window, surface, event, elwt| {
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {

--- a/benches/buffer_mut.rs
+++ b/benches/buffer_mut.rs
@@ -18,6 +18,7 @@ fn buffer_mut(c: &mut Criterion) {
         use winit::platform::run_on_demand::EventLoopExtRunOnDemand;
 
         let mut evl = winit::event_loop::EventLoop::new().unwrap();
+        let context = Context::new(evl.owned_display_handle()).unwrap();
         let window = evl
             .create_window(winit::window::Window::default_attributes().with_visible(false))
             .unwrap();
@@ -28,10 +29,7 @@ fn buffer_mut(c: &mut Criterion) {
             if let winit::event::Event::AboutToWait = ev {
                 elwt.exit();
 
-                let mut surface = {
-                    let context = Context::new(elwt).unwrap();
-                    Surface::new(&context, &window).unwrap()
-                };
+                let mut surface = Surface::new(&context, &window).unwrap();
 
                 let size = window.inner_size();
                 surface

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -14,23 +14,23 @@ fn main() {
     let event_loop = EventLoop::new().unwrap();
     let start = Instant::now();
 
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
+
     let app = winit_app::WinitAppBuilder::with_init(
         |event_loop| {
             let window = winit_app::make_window(event_loop, |w| w);
 
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
             let old_size = (0, 0);
             let frames = pre_render_frames(0, 0);
 
-            (window, context, old_size, frames)
+            (window, old_size, frames)
         },
-        |_elwft, (window, context, _old_size, _frames)| {
-            softbuffer::Surface::new(context, window.clone()).unwrap()
+        move |_elwft, (window, _old_size, _frames)| {
+            softbuffer::Surface::new(&context, window.clone()).unwrap()
         },
     )
     .with_event_handler(move |state, surface, event, elwt| {
-        let (window, _context, old_size, frames) = state;
+        let (window, old_size, frames) = state;
 
         elwt.set_control_flow(ControlFlow::Poll);
 

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -13,19 +13,16 @@ fn main() {
     let (width, height) = (fruit.width(), fruit.height());
 
     let event_loop = EventLoop::new().unwrap();
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
 
     let app = winit_app::WinitAppBuilder::with_init(
         move |elwt| {
-            let window = winit_app::make_window(elwt, |w| {
+            winit_app::make_window(elwt, |w| {
                 w.with_inner_size(winit::dpi::PhysicalSize::new(width, height))
-            });
-
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
-            (window, context)
+            })
         },
-        move |_elwt, (window, context)| {
-            let mut surface = softbuffer::Surface::new(context, window.clone()).unwrap();
+        move |_elwt, window| {
+            let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
             // Intentionally only set the size of the surface once, at creation.
             // This is needed if the window chooses to ignore the size we passed in above, and for the
             // platforms softbuffer supports that don't yet extract the size from the window.
@@ -38,8 +35,7 @@ fn main() {
             surface
         },
     )
-    .with_event_handler(move |state, surface, event, elwt| {
-        let (window, _context) = state;
+    .with_event_handler(move |window, surface, event, elwt| {
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -24,6 +24,7 @@ fn redraw(buffer: &mut [u32], width: usize, height: usize, flag: bool) {
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
 
     let app = winit_app::WinitAppBuilder::with_init(
         |elwt| {
@@ -31,18 +32,14 @@ fn main() {
                 w.with_title("Press space to show/hide a rectangle")
             });
 
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
             let flag = false;
 
-            (window, context, flag)
+            (window, flag)
         },
-        |_elwt, (window, context, _flag)| {
-            softbuffer::Surface::new(context, window.clone()).unwrap()
-        },
+        move |_elwt, (window, _flag)| softbuffer::Surface::new(&context, window.clone()).unwrap(),
     )
     .with_event_handler(|state, surface, event, elwt| {
-        let (window, _context, flag) = state;
+        let (window, flag) = state;
 
         elwt.set_control_flow(ControlFlow::Wait);
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -12,17 +12,13 @@ fn main() {
 }
 
 pub(crate) fn entry(event_loop: EventLoop<()>) {
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
+
     let app = winit_app::WinitAppBuilder::with_init(
-        |elwt| {
-            let window = winit_app::make_window(elwt, |w| w);
-
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
-            (window, context)
-        },
-        |_elwt, (window, context)| softbuffer::Surface::new(context, window.clone()).unwrap(),
+        |elwt| winit_app::make_window(elwt, |w| w),
+        move |_elwt, window| softbuffer::Surface::new(&context, window.clone()).unwrap(),
     )
-    .with_event_handler(|(window, _context), surface, event, elwt| {
+    .with_event_handler(|window, surface, event, elwt| {
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -11,17 +11,12 @@ const BUFFER_HEIGHT: usize = 128;
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();
+    let context = softbuffer::Context::new(event_loop.owned_display_handle()).unwrap();
 
     let app = winit_app::WinitAppBuilder::with_init(
-        |elwt| {
-            let window = winit_app::make_window(elwt, |w| w);
-
-            let context = softbuffer::Context::new(window.clone()).unwrap();
-
-            (window, context)
-        },
-        |_elwt, (window, context)| {
-            let mut surface = softbuffer::Surface::new(context, window.clone()).unwrap();
+        |elwt| winit_app::make_window(elwt, |w| w),
+        move |_elwt, window| {
+            let mut surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
             // Intentionally set the size of the surface to something different than the size of the window.
             surface
                 .resize(
@@ -32,8 +27,7 @@ fn main() {
             surface
         },
     )
-    .with_event_handler(|state, surface, event, elwt| {
-        let (window, _context) = state;
+    .with_event_handler(|window, surface, event, elwt| {
         elwt.set_control_flow(ControlFlow::Wait);
 
         match event {

--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -17,6 +17,7 @@ macro_rules! make_dispatch {
             ($context_inner: ty, $surface_inner: ty, $buffer_inner: ty),
         )*
     ) => {
+        #[derive(Clone)]
         pub(crate) enum ContextDispatch<$dgen> {
             $(
                 $(#[$attr])*

--- a/src/backends/web.rs
+++ b/src/backends/web.rs
@@ -18,6 +18,7 @@ use std::num::NonZeroU32;
 /// Display implementation for the web platform.
 ///
 /// This just caches the document to prevent having to query it every time.
+#[derive(Clone)]
 pub struct WebDisplayImpl<D> {
     document: web_sys::Document,
     _display: D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use backends::web::SurfaceExtWeb;
 
 /// An instance of this struct contains the platform-specific data that must be managed in order to
 /// write to a window on that platform.
+#[derive(Clone)]
 pub struct Context<D> {
     /// The inner static dispatch object.
     context_impl: ContextDispatch<D>,


### PR DESCRIPTION
Simplify creation of `Context` in examples by constructing it before running the event loop with the new-ish [`EventLoop::owned_display_handle`](https://docs.rs/winit/0.30.11/winit/event_loop/struct.EventLoop.html#method.owned_display_handle).

This PR also makes `Context` `Clone` when the inner display handle is, to allow more easily passing it around.