### PR TITLE
fix(kms): run modesetting after the surface is resized

### DIFF
--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -3,7 +3,7 @@
 #[cfg(kms_platform)]
 mod imple {
     use drm::control::{connector, Device as CtrlDevice, Event, ModeTypeFlags, PlaneType};
-    use drm::Device;
+    use drm::{ClientCapability, Device};
 
     use raw_window_handle::{DisplayHandle, DrmDisplayHandle, DrmWindowHandle, WindowHandle};
     use softbuffer::{Context, Surface};
@@ -16,6 +16,7 @@ mod imple {
     pub(super) fn entry() -> Result<(), Box<dyn std::error::Error>> {
         // Open a new device.
         let device = Card::find()?;
+        device.set_client_capability(ClientCapability::UniversalPlanes, true)?;
 
         // Create the softbuffer context.
         let context = unsafe {

--- a/src/backends/kms.rs
+++ b/src/backends/kms.rs
@@ -224,6 +224,29 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
         let front_buffer = SharedBuffer::new(&self.display, width, height)?;
         let back_buffer = SharedBuffer::new(&self.display, width, height)?;
 
+        // Iterate over all modes of all the connectors,
+        // and pick one that is compatible with the size given by the user.
+        let mode = self
+            .connectors
+            .iter()
+            .flat_map(|con| self.display.get_modes(*con).unwrap())
+            .find(|mode| {
+                mode.size().0 as u32 == u32::from(width)
+                    && mode.size().1 as u32 == u32::from(height)
+            })
+            .swbuf_err("No mode found")?;
+
+        // When chaning the display resolution, we need to modeset
+        self.display
+            .set_crtc(
+                self.crtc.handle(),
+                Some(front_buffer.fb),
+                (0, 0),
+                &self.connectors,
+                Some(mode),
+            )
+            .swbuf_err("Failed to modeset")?;
+
         self.buffer = Some(Buffers {
             first_is_front: true,
             buffers: [front_buffer, back_buffer],


### PR DESCRIPTION
When the user called `Surface::resize` with the `kms` backend, no modesetting was done. At least on the devices I tested with, this made the page flips fail, returning `EBUSY`. This is now fixed by calling `set_crtc` inside the `resize` function.

Additionally, I made the drm example request the UniversalPlanes ClientCapability, since that allows the example to run on less powerful devices that don't have any overlay planes (Unless the client sets that capability, the kernel only returns overlay frames from the `Device::plane_handles()` call).

Fixes #271.