### PR TITLE
Release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Unreleased
 
-- Update to `objc2` 0.6.0.
-- Bump MSRV to Rust 1.71.
-- Make `Context` cloneable.
-- Added `Buffer::width()` and `Buffer::height()` getters.
+# 0.4.7
+
+- Added support for Android using the `ndk` crate.
 - Added support for `wasm64-*` targets.
+- Improved examples.
+- Added `Buffer::width()` and `Buffer::height()` getters.
+- `Context` now implements `Clone`.
 - `Context`, `Surface` and `Buffer` now implement `Debug`.
+- Bump MSRV to Rust 1.71.
+- Replace `log` with `tracing`.
+- Remove `cfg_aliases` dependency.
+- Update to `objc2` 0.6, `objc2-*` 0.3, `drm` 0.14, `rustix` 1.0 and `windows-sys` 0.61.
 
 # 0.4.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softbuffer"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform software buffer"


### PR DESCRIPTION
Changes:
- Added support for Android using the `ndk` crate.
- Added support for `wasm64-*` targets.
- Improved examples.
- Added `Buffer::width()` and `Buffer::height()` getters.
- `Context` now implements `Clone`.
- `Context`, `Surface` and `Buffer` now implement `Debug`.
- Bump MSRV to Rust 1.71.
- Replace `log` with `tracing`.
- Remove `cfg_aliases` dependency.
- Update to `objc2` 0.6, `objc2-*` 0.3, `drm` 0.14, `rustix` 1.0 and `windows-sys` 0.61.
