### PR TITLE
android: Fix no-op swizzle to actually convert from BGR(A) to RGB(A)

### DIFF
--- a/src/backends/android.rs
+++ b/src/backends/android.rs
@@ -160,12 +160,12 @@ impl<'a, D: HasDisplayHandle, W: HasWindowHandle> BufferInterface for BufferImpl
             assert_eq!(output.len(), input.len() * 4);
 
             for (i, pixel) in input.iter().enumerate() {
-                // Swizzle colors from RGBX to BGR
-                let [b, g, r, _] = pixel.to_le_bytes();
-                output[i * 4].write(b);
+                // Swizzle colors from BGR(A) to RGB(A)
+                let [b, g, r, a] = pixel.to_le_bytes();
+                output[i * 4].write(r);
                 output[i * 4 + 1].write(g);
-                output[i * 4 + 2].write(r);
-                // TODO alpha?
+                output[i * 4 + 2].write(b);
+                output[i * 4 + 3].write(a);
             }
         }
         Ok(())


### PR DESCRIPTION
When a temporary buffer copy for swizzling and padding was implemented in commit a16fb9a ("android: Implement format swizzle via buffer copies"), the swizzle was implemented incorrectly and kept the b component in the lowest byte matching `softbuffer`'s BGR order while Android only has RGB formats.  The inversion in the comment and forgotten alpha channel didn't make things any clearer.

The example clearly modulates the **red** channel in the horizontal axis, but this gets lost before this change. 

| `main` | This PR |
|-|-|
| <img width="1080" height="2340" alt="Screenshot_20251123-182756" src="https://github.com/user-attachments/assets/fb224b05-ef25-4fe0-8e78-af16e0195734" /> | <img width="1080" height="2340" alt="Screenshot_20251123-182736" src="https://github.com/user-attachments/assets/6e728cb3-eed1-4fba-9738-ddc5b9a5e550" /> |

| Desktop (Wayland), before and after |
|-|
| <img width="802" height="602" alt="image" src="https://github.com/user-attachments/assets/6e9b35ce-9e70-477c-913e-48f522c4b621" /> |

