### PR TITLE
Use `target_family = "wasm"` instead of `target_arch = "wasm32"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bump MSRV to Rust 1.71.
 - Make `Context` cloneable.
 - Added `Buffer::width()` and `Buffer::height()` getters.
+- Added support for `wasm64-*` targets.
 
 # 0.4.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,11 +110,11 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
     "CATransaction",
 ] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.63"
 wasm-bindgen = "0.2.86"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+[target.'cfg(target_family = "wasm")'.dependencies.web-sys]
 version = "0.3.55"
 features = [
     "CanvasRenderingContext2d",
@@ -148,11 +148,11 @@ version = "0.25.0"
 default-features = false
 features = ["jpeg"]
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 # Turn rayon back on everywhere else; creating the separate entry resets the features to default.
 rayon = "1.5.1"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_vendor = "apple", target_os = "redox", target_family = "wasm", target_os = "windows")))'.dev-dependencies]

--- a/benches/buffer_mut.rs
+++ b/benches/buffer_mut.rs
@@ -3,13 +3,13 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn buffer_mut(c: &mut Criterion) {
-    #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+    #[cfg(target_family = "wasm")]
     {
         // Do nothing.
         let _ = c;
     }
 
-    #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+    #[cfg(not(target_family = "wasm"))]
     {
         use criterion::black_box;
         use softbuffer::{Context, Surface};

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 use std::f64::consts::PI;
 use std::num::NonZeroU32;
@@ -115,9 +115,9 @@ fn pre_render_frames(width: u32, height: u32) -> Vec<Vec<u32>> {
             .collect::<Vec<_>>()
     };
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     return (0..60).map(render).collect();
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     (0..60).into_par_iter().map(render).collect()
 }

--- a/examples/utils/winit_app.rs
+++ b/examples/utils/winit_app.rs
@@ -10,10 +10,10 @@ use winit::window::{Window, WindowAttributes, WindowId};
 /// Run a Winit application.
 #[allow(unused_mut)]
 pub(crate) fn run_app(event_loop: EventLoop<()>, mut app: impl ApplicationHandler<()> + 'static) {
-    #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+    #[cfg(not(target_family = "wasm"))]
     event_loop.run_app(&mut app).unwrap();
 
-    #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+    #[cfg(target_family = "wasm")]
     winit::platform::web::EventLoopExtWebSys::spawn_app(event_loop, app);
 }
 
@@ -24,7 +24,7 @@ pub(crate) fn make_window(
     f: impl FnOnce(WindowAttributes) -> WindowAttributes,
 ) -> Rc<Window> {
     let attributes = f(WindowAttributes::default());
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     let attributes = winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
     let window = elwt.create_window(attributes);
     Rc::new(window.unwrap())

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -65,7 +65,7 @@ pub mod ex {
         let app = winit_app::WinitAppBuilder::with_init(
             |elwt| {
                 let attributes = Window::default_attributes();
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(target_family = "wasm")]
                 let attributes =
                     winit::platform::web::WindowAttributesExtWebSys::with_append(attributes, true);
                 let window = Arc::new(elwt.create_window(attributes).unwrap());

--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -236,7 +236,7 @@ make_dispatch! {
     Win32(D, backends::win32::Win32Impl<D, W>, backends::win32::BufferImpl<'a, D, W>),
     #[cfg(target_vendor = "apple")]
     CoreGraphics(D, backends::cg::CGImpl<D, W>, backends::cg::BufferImpl<'a, D, W>),
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     Web(backends::web::WebDisplayImpl<D>, backends::web::WebImpl<D, W>, backends::web::BufferImpl<'a, D, W>),
     #[cfg(target_os = "redox")]
     Orbital(D, backends::orbital::OrbitalImpl<D, W>, backends::orbital::BufferImpl<'a, D, W>),

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod orbital;
     ))
 ))]
 pub(crate) mod wayland;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub(crate) mod web;
 #[cfg(target_os = "windows")]
 pub(crate) mod win32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use error::SoftBufferError;
 
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use backends::web::SurfaceExtWeb;
 
 /// An instance of this struct contains the platform-specific data that must be managed in order to


### PR DESCRIPTION
This allows using `wasm64-*` targets as well.