### PR TITLE
CI: Only run `cargo check` for MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,71 @@ jobs:
     - name: Run Typos
       run: typos
 
+  msrv:
+    name: MSRV
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # Android
+        - target: aarch64-linux-android
+
+        # CoreGraphics
+        - target: aarch64-apple-darwin
+        - target: x86_64-apple-ios
+
+        # Orbital (doesn't follow MSRV)
+        # - target: x86_64-unknown-redox
+
+        # Wayland, KMS/DRM, X11
+        - target: i686-unknown-linux-gnu
+        - target: x86_64-unknown-linux-gnu
+        - target: x86_64-unknown-linux-gnu
+          features: "x11,x11-dlopen"
+        - target: x86_64-unknown-linux-gnu
+          features: "wayland,wayland-dlopen"
+        - target: x86_64-unknown-linux-gnu
+          features: "kms"
+        - target: x86_64-unknown-freebsd
+        - target: x86_64-unknown-netbsd
+          features: "x11,x11-dlopen,wayland,wayland-dlopen"
+
+        # Web
+        - target: wasm32-unknown-unknown
+
+        # Win32
+        - target: x86_64-pc-windows-msvc
+        - target: x86_64-pc-windows-gnu
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: '1.71.1'
+        targets: ${{ matrix.target }}
+
+    - name: Use minimal dependency versions
+      # By downgrading all our dependency versions, we ensure that our minimum
+      # version bounds are actually adequate (i.e. users can build `softbuffer`
+      # with minimal versions themselves) and opt-out of any unexpected MSRV
+      # bumps in semver-compatible releases of downstream crates.
+      #
+      # RUSTC_BOOTSTRAP=1 is kind of a hack, but it's cumbersome and slow to
+      # install the nightly toolchain.
+      run: RUSTC_BOOTSTRAP=1 cargo -Zminimal-versions generate-lockfile
+
+    - name: Check that crate compiles
+      run: cargo check --verbose --target ${{ matrix.target }} ${{ matrix.features && '--no-default-features --features' }} ${{ matrix.features }}
+
   tests:
     name: Tests
     needs: fmt
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ['1.71.0', stable, nightly]
+        rust_version: [stable, nightly]
         platform:
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
           - { target: i686-pc-windows-msvc,     os: windows-latest,  }
@@ -49,10 +107,6 @@ jobs:
           - { target: x86_64-unknown-netbsd,    os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen,wayland,wayland-dlopen"  }
           - { target: aarch64-apple-darwin,     os: macos-latest,    }
           - { target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
-        exclude:
-          # Orbital doesn't follow MSRV
-          - rust_version: '1.71.0'
-            platform: { target: x86_64-unknown-redox, os: ubuntu-latest }
         include:
           - rust_version: nightly
             platform: { target: wasm32-unknown-unknown, os: ubuntu-latest, options: "-Zbuild-std=panic_abort,std", rustflags: "-Ctarget-feature=+atomics,+bulk-memory" }
@@ -80,27 +134,6 @@ jobs:
       if: matrix.platform.target == 'wasm32-unknown-unknown'
       with:
         tool: wasm-bindgen-cli
-
-    - name: Install nightly rust to generate `-Zminimal-versions` lockfile (for MSRV)
-      if: matrix.rust_version == '1.71.0'
-      uses: dtolnay/rust-toolchain@nightly
-
-    - name: Pin deps that break MSRV
-      if: matrix.rust_version == '1.71.0'
-      # By downgrading all our dependency versions, we ensure that our minimum
-      # version bounds are actually adequate (i.e. users can build `softbuffer`
-      # with minimal versions themselves) and opt-out of any unexpected MSRV
-      # bumps in semver-compatible releases of downstream crates.
-      run: |
-        cargo -Zminimal-versions generate-lockfile
-        # Bump `regex` - only used by our `dev-dependencies` `criterion` dependency - to fix:
-        # https://github.com/rust-lang/regex/issues/931
-        # Can be removed on the next `criterion` upgrade: https://github.com/bheisler/criterion.rs/pull/821
-        cargo update -p regex --precise 1.5.1
-        cargo update -p num-traits --precise 0.2.16 # Unconditional i128 support used by image
-        cargo update -p anyhow --precise 1.0.19 # walrus needs bail!() string support from 1.0.1, wasm-bindgen-cli-support requires format_err from 1.0.19
-        cargo update -p foreign-types-macros --precise 0.2.2 # `core-graphics 0.23.1` from `winit 0.30` fails to compile on 0.2.1
-        cargo update -p same-file --precise 1.0.5 # First release with `unknown` support for wasm32
 
     - uses: hecrj/setup-rust-action@v2
       with:


### PR DESCRIPTION
It should be enough to verify that the code compiles, we're testing it elsewhere, and we don't need development dependencies to follow MSRV.

Semi alternative to https://github.com/rust-windowing/softbuffer/pull/260 (since after this, I suspect we're gonna run into much fewer problems with MSRV breaking CI).