### PR TITLE
Fix documentation on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix documentation building on `docs.rs`.
+
 # 0.4.7
 
 - Added support for Android using the `ndk` crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate core;
 


### PR DESCRIPTION
We were using the `doc_auto_cfg` feature, but that's been renamed to just `doc_cfg`.

This causes the documentation to fail building on docs.rs, see [the build logs](https://docs.rs/crate/softbuffer/latest/builds/2730258).

I'll submit a new release after this.