### PR TITLE
Disable the KMS/DRM backend by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
 
         # Wayland, KMS/DRM, X11
         - target: i686-unknown-linux-gnu
+          features: "kms,x11,x11-dlopen,wayland,wayland-dlopen"
         - target: x86_64-unknown-linux-gnu
+          features: "kms,x11,x11-dlopen,wayland,wayland-dlopen"
         - target: x86_64-unknown-linux-gnu
           features: "x11,x11-dlopen"
         - target: x86_64-unknown-linux-gnu
@@ -53,6 +55,7 @@ jobs:
         - target: x86_64-unknown-linux-gnu
           features: "kms"
         - target: x86_64-unknown-freebsd
+          features: "kms,x11,x11-dlopen,wayland,wayland-dlopen"
         - target: x86_64-unknown-netbsd
           features: "x11,x11-dlopen,wayland,wayland-dlopen"
 
@@ -98,7 +101,7 @@ jobs:
           # - { target: x86_64-pc-windows-gnu,    os: windows-latest, host: -x86_64-pc-windows-gnu }
           # - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, features: "kms" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "x11,x11-dlopen" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
           # Build with default Winit backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking:** Removed generic type parameters `D` and `W` from `Buffer<'_>` struct.
 - **Breaking:** Removed `Deref[Mut]` implementation on `Buffer<'_>`. Use `Buffer::pixels()` instead.
 - **Breaking:** Removed unintentional Cargo features for Softbuffer's optional dependencies.
+- **Breaking:** Disable the DRM/KMS backend by default.
 - **Breaking:** Removed `DamageOutOfRange` error case. If the damage value is greater than the backend supports, it is instead clamped to an appropriate value.
 - Fixed `present_with_damage` with bounds out of range on Windows, Web and X11.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["game-development", "graphics", "gui", "multimedia", "rendering"]
 exclude = ["examples"]
 
 [features]
-default = ["wayland", "wayland-dlopen", "x11", "x11-dlopen", "kms"]
+default = ["wayland", "wayland-dlopen", "x11", "x11-dlopen"]
 
 # Enable the Wayland backend.
 wayland = [


### PR DESCRIPTION
The backend was introduced in https://github.com/rust-windowing/softbuffer/pull/135 to fix https://github.com/rust-windowing/softbuffer/pull/42, but I feel like it's somewhat too niche for us to support as a "primary" platform.

In a sense, this is in preparation for some day dropping X11 as a default platform too (though that's years in the future, and should be coordinated with Winit).

Then again, maybe the cost of the extra `drm-*` dependencies isn't large enough that it really matters?

WDYT?