### PR TITLE
Add `Buffer::pixel_rows` and `Buffer::pixels_iter` iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-- **Breaking:** Remove generic type parameters `D` and `W` from `Buffer<'_>` struct.
+- Added `Buffer::pixel_rows()` for iterating over rows of the buffer data.
+- Added `Buffer::pixels_iter()` for iterating over each pixel with its associated `x`/`y` coordinate.
+- **Breaking:** Removed generic type parameters `D` and `W` from `Buffer<'_>` struct.
 
 # 0.4.7
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,12 @@ fn main() {
                     .unwrap();
 
                 let mut buffer = surface.buffer_mut().unwrap();
-                for index in 0..(buffer.width().get() * buffer.height().get()) {
-                    let y = index / buffer.width().get();
-                    let x = index % buffer.width().get();
+                for (x, y, pixel) in buffer.pixels_iter() {
                     let red = x % 255;
                     let green = y % 255;
                     let blue = (x * y) % 255;
 
-                    buffer[index as usize] = blue | (green << 8) | (red << 16);
+                    *pixel = blue | (green << 8) | (red << 16);
                 }
 
                 buffer.present().unwrap();

--- a/benches/buffer_mut.rs
+++ b/benches/buffer_mut.rs
@@ -40,7 +40,7 @@ fn buffer_mut(c: &mut criterion::Criterion) {
                 });
             });
 
-            c.bench_function("pixels_mut()", |b| {
+            c.bench_function("data()", |b| {
                 let mut buffer = surface.buffer_mut().unwrap();
                 b.iter(|| {
                     let pixels: &mut [u32] = &mut buffer;
@@ -48,7 +48,7 @@ fn buffer_mut(c: &mut criterion::Criterion) {
                 });
             });
 
-            c.bench_function("fill", |b| {
+            c.bench_function("fill u32", |b| {
                 let mut buffer = surface.buffer_mut().unwrap();
                 b.iter(|| {
                     let buffer = black_box(&mut buffer);
@@ -56,19 +56,15 @@ fn buffer_mut(c: &mut criterion::Criterion) {
                 });
             });
 
-            c.bench_function("render", |b| {
+            c.bench_function("render pixels_iter", |b| {
                 let mut buffer = surface.buffer_mut().unwrap();
                 b.iter(|| {
                     let buffer = black_box(&mut buffer);
-                    let width = buffer.width().get();
-                    for y in 0..buffer.height().get() {
-                        for x in 0..buffer.width().get() {
-                            let red = (x & 0xff) ^ (y & 0xff);
-                            let green = (x & 0x7f) ^ (y & 0x7f);
-                            let blue = (x & 0x3f) ^ (y & 0x3f);
-                            let value = blue | (green << 8) | (red << 16);
-                            buffer[(y * width + x) as usize] = value;
-                        }
+                    for (x, y, pixel) in buffer.pixels_iter() {
+                        let red = (x & 0xff) ^ (y & 0xff);
+                        let green = (x & 0x7f) ^ (y & 0x7f);
+                        let blue = (x & 0x3f) ^ (y & 0x3f);
+                        *pixel = blue | (green << 8) | (red << 16);
                     }
                 });
             });

--- a/examples/raytracing/game.rs
+++ b/examples/raytracing/game.rs
@@ -108,13 +108,11 @@ impl Game {
         }
 
         // Upscale by `scale_factor`.
-        let width = buffer.width().get() as usize;
-        buffer.iter_mut().enumerate().for_each(|(i, pixel)| {
-            let y = i % width;
-            let x = i / width;
-            let y = (y as f32 / scale_factor) as usize;
+        let width = (buffer.width().get() as f32 / scale_factor) as usize;
+        buffer.pixels_iter().for_each(|(x, y, pixel)| {
             let x = (x as f32 / scale_factor) as usize;
-            if let Some(x) = pixels.get(x * (width as f32 / scale_factor) as usize + y) {
+            let y = (y as f32 / scale_factor) as usize;
+            if let Some(x) = pixels.get(x * width + y) {
                 *pixel = *x;
             }
         });
@@ -149,8 +147,7 @@ impl Game {
             },
         ];
 
-        let width = buffer.width().get();
-        for (y, row) in buffer.chunks_exact_mut(width as usize).enumerate() {
+        for (y, row) in buffer.pixel_rows().enumerate() {
             for rect in rects {
                 let rect_vertical =
                     (rect.top * scale_factor) as usize..(rect.bottom * scale_factor) as usize;

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -9,18 +9,15 @@ mod util;
 fn redraw(buffer: &mut Buffer<'_>, flag: bool) {
     let width = buffer.width().get();
     let height = buffer.height().get();
-    for y in 0..height {
-        for x in 0..width {
-            let value = if flag && x >= 100 && x < width - 100 && y >= 100 && y < height - 100 {
-                0x00ffffff
-            } else {
-                let red = (x & 0xff) ^ (y & 0xff);
-                let green = (x & 0x7f) ^ (y & 0x7f);
-                let blue = (x & 0x3f) ^ (y & 0x3f);
-                blue | (green << 8) | (red << 16)
-            };
-            buffer[(y * width + x) as usize] = value;
-        }
+    for (x, y, pixel) in buffer.pixels_iter() {
+        *pixel = if flag && x >= 100 && x < width - 100 && y >= 100 && y < height - 100 {
+            0x00ffffff
+        } else {
+            let red = (x & 0xff) ^ (y & 0xff);
+            let green = (x & 0x7f) ^ (y & 0x7f);
+            let blue = (x & 0x3f) ^ (y & 0x3f);
+            blue | (green << 8) | (red << 16)
+        };
     }
 }
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -46,14 +46,11 @@ pub(crate) fn entry(event_loop: EventLoop<()>) {
                 };
 
                 let mut buffer = surface.buffer_mut().unwrap();
-                for y in 0..buffer.height().get() {
-                    for x in 0..buffer.width().get() {
-                        let red = x % 255;
-                        let green = y % 255;
-                        let blue = (x * y) % 255;
-                        let index = y * buffer.width().get() + x;
-                        buffer[index as usize] = blue | (green << 8) | (red << 16);
-                    }
+                for (x, y, pixel) in buffer.pixels_iter() {
+                    let red = x % 255;
+                    let green = y % 255;
+                    let blue = (x * y) % 255;
+                    *pixel = blue | (green << 8) | (red << 16);
                 }
 
                 buffer.present().unwrap();

--- a/examples/winit_multithread.rs
+++ b/examples/winit_multithread.rs
@@ -32,14 +32,11 @@ pub mod ex {
             surface.resize(width, height).unwrap();
 
             let mut buffer = surface.buffer_mut().unwrap();
-            for y in 0..buffer.height().get() {
-                for x in 0..buffer.width().get() {
-                    let red = x % 255;
-                    let green = y % 255;
-                    let blue = (x * y) % 255;
-                    let index = y * buffer.width().get() + x;
-                    buffer[index as usize] = blue | (green << 8) | (red << 16);
-                }
+            for (x, y, pixel) in buffer.pixels_iter() {
+                let red = x % 255;
+                let green = y % 255;
+                let blue = (x * y) % 255;
+                *pixel = blue | (green << 8) | (red << 16);
             }
 
             tracing::info!("presenting...");

--- a/examples/winit_wrong_sized_buffer.rs
+++ b/examples/winit_wrong_sized_buffer.rs
@@ -37,16 +37,11 @@ fn main() {
                 };
 
                 let mut buffer = surface.buffer_mut().unwrap();
-                let width = buffer.width().get();
-                for y in 0..buffer.height().get() {
-                    for x in 0..width {
-                        let red = x % 255;
-                        let green = y % 255;
-                        let blue = (x * y) % 255;
-
-                        let color = blue | (green << 8) | (red << 16);
-                        buffer[(y * width + x) as usize] = color;
-                    }
+                for (x, y, pixel) in buffer.pixels_iter() {
+                    let red = x % 255;
+                    let green = y % 255;
+                    let blue = (x * y) % 255;
+                    *pixel = blue | (green << 8) | (red << 16);
                 }
                 buffer.present().unwrap();
             }


### PR DESCRIPTION
Add:
```rust
impl Buffer<'_> {
    pub fn pixel_rows(&mut self) -> impl Iterator<Item = &mut [u32]> + DoubleEndedIterator + ExactSizeIterator;
    pub fn pixels_iter(&mut self) -> impl Iterator<Item = (u32, u32, &mut u32)> + DoubleEndedIterator;
}
```

`pixel_rows` is a prerequisite for https://github.com/rust-windowing/softbuffer/issues/291, as using a buffer with stride will be quite cumbersome without them. It currently chunks on the width, but should chunk on the stride once we add that. `pixels_iter` is more of a useful shorthand, it's not as critical, but still be nice to have.

I decided to return opaque `impl Iterator<...>`, we can add an explicit `BufferRows<'_>` iterator type later if desirable.