### PR TITLE
Allow reading from buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,33 +271,9 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> HasWindowHandle for Surface<D, W> 
 ///
 /// # Reading buffer data
 ///
-/// Reading from buffer data may perform very poorly, as the underlying storage of zero-copy
-/// buffers, where implemented, may set options optimized for CPU writes, that allows them to bypass
-/// certain caches and avoid cache pollution.
-///
-/// As such, when rendering, you should always set the pixel in its entirety:
-///
-/// ```
-/// # use softbuffer::Pixel;
-/// # let pixel = &mut Pixel::default();
-/// # let (red, green, blue) = (0x11, 0x22, 0x33);
-/// *pixel = Pixel::new_rgb(red, green, blue);
-/// ```
-///
-/// Instead of e.g. something like:
-///
-/// ```
-/// # use softbuffer::Pixel;
-/// # let pixel = &mut Pixel::default();
-/// # let (red, green, blue) = (0x11, 0x22, 0x33);
-/// // DISCOURAGED!
-/// *pixel = Pixel::default(); // Clear
-/// pixel.r |= red;
-/// pixel.g |= green;
-/// pixel.b |= blue;
-/// ```
-///
-/// To discourage reading from the buffer, `&self -> &[u8]` methods are intentionally not provided.
+/// The API of this is simplified for writing to buffer data, so various `&self -> &[X]` methods are
+/// intentionally not provided. You can still read from the buffer data via. the `&mut self` methods
+/// though.
 ///
 /// # Platform dependent behavior
 ///


### PR DESCRIPTION
In https://github.com/rust-windowing/softbuffer/pull/313, I added a note that reading from the pixel buffer is discouraged, because I wanted to set `kIOSurfaceMapWriteCombineCache` on macOS once I got around to implementing proper `IOSurface` support. See e.g. the following links for a few places where it's used in the wild:
- WebKit on iOS: https://bugs.webkit.org/show_bug.cgi?id=130982
- Chromium (was later backed out though): https://chromium-review.googlesource.com/c/chromium/src/+/6575828

I thought this was fine, because I couldn't see a use-case where you'd need to read from the pixel buffer, but that was perhaps a bit hasty, I found at least one use-case: converting the alpha mode (premultiplying components or making the alpha channel opaque) by modifying the buffer in-place in a separate step before presenting it buffer.

This means that the argument for only having the mutable version instead of distinct `pixels/pixels_mut`, `pixel_rows/pixel_rows_mut` and `pixels_iter/pixels_iter_mut` methods is a bit weaker.

WDYT? Should we provide both immutable and mutable methods on `Buffer<'_>`?