### PR TITLE
Add `AlphaMode` and transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added `AlphaMode` to allow configuring transparency and zero-copy on Web. Set it with `Surface::configure`.
+- Added `Surface::supports_alpha_mode` for querying supported alpha modes.
 - Added `PixelFormat` enum.
 - Added `Buffer::pixels()` for accessing the buffer's pixel data.
 - Added `Buffer::pixel_rows()` for iterating over rows of the buffer data.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ drm = { version = "0.14.1", default-features = false, optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = [
     "Win32_Graphics_Gdi",
+    "Win32_UI_ColorSystem",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",

--- a/examples/transparency.rs
+++ b/examples/transparency.rs
@@ -1,0 +1,168 @@
+//! An example to test transparent rendering.
+//!
+//! Press `1`, `2`, `3` or `4` to change the alpha mode to `Opaque`, `Ignored`, `Premultiplied` and
+//! `Postmultiplied` respectively.
+//!
+//! This should render 6 rectangular areas. For details on the terminology, see:
+//! <https://html.spec.whatwg.org/multipage/canvas.html#premultiplied-alpha-and-the-2d-rendering-context>
+//!
+//! (255, 127, 0, 255):
+//! - Opaque/Ignored: Completely-opaque orange.
+//! - Postmultiplied: Completely-opaque orange.
+//! - Premultiplied:  Completely-opaque orange.
+//!
+//! (255, 255, 0, 127):
+//! - Opaque/Ignored: Completely-opaque yellow.
+//! - Postmultiplied: Halfway-opaque yellow.
+//! - Premultiplied:  Additive halfway-opaque yellow.
+//!
+//! (127, 127, 0, 127):
+//! - Opaque/Ignored: Completely-opaque dark yellow.
+//! - Postmultiplied: Halfway-opaque dark yellow.
+//! - Premultiplied:  Halfway-opaque yellow.
+//!
+//! (255, 127, 0, 127):
+//! - Opaque/Ignored: Completely-opaque orange.
+//! - Postmultiplied: Halfway-opaque orange.
+//! - Premultiplied:  Additive halfway-opaque orange.
+//!
+//! (255, 127, 0, 0):
+//! - Opaque/Ignored: Completely-opaque orange.
+//! - Postmultiplied: Fully-transparent orange.
+//! - Premultiplied:  Additive fully-transparent orange.
+//!
+//! (0, 0, 0, 0):
+//! - Opaque/Ignored: Completely-opaque black.
+//! - Postmultiplied: Fully-transparent.
+//! - Premultiplied:  Fully-transparent.
+//!
+//! For images of the expected output, see <https://github.com/rust-windowing/softbuffer/pull/321>.
+use softbuffer::{AlphaMode, Context, Pixel, Surface};
+use std::num::NonZeroU32;
+use winit::event::{ElementState, KeyEvent, WindowEvent};
+use winit::event_loop::{ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
+
+mod util;
+
+fn main() {
+    util::setup();
+
+    let event_loop = EventLoop::new().unwrap();
+
+    let context = Context::new(event_loop.owned_display_handle()).unwrap();
+
+    let app = util::WinitAppBuilder::with_init(
+        |elwt| util::make_window(elwt, |w| w),
+        move |_elwt, window| Surface::new(&context, window.clone()).unwrap(),
+    )
+    .with_event_handler(|window, surface, window_id, event, elwt| {
+        elwt.set_control_flow(ControlFlow::Wait);
+
+        if window_id != window.id() {
+            return;
+        }
+
+        match event {
+            WindowEvent::Resized(size) => {
+                let Some(surface) = surface else {
+                    tracing::error!("Resized fired before Resumed or after Suspended");
+                    return;
+                };
+
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+                {
+                    surface.resize(width, height).unwrap();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let Some(surface) = surface else {
+                    tracing::error!("RedrawRequested fired before Resumed or after Suspended");
+                    return;
+                };
+
+                tracing::info!(alpha_mode = ?surface.alpha_mode(), "redraw");
+
+                let mut buffer = surface.next_buffer().unwrap();
+                let width = buffer.width().get();
+                let alpha_mode = buffer.alpha_mode();
+                for (x, _, pixel) in buffer.pixels_iter() {
+                    let rectangle_number = (x * 6) / width;
+                    *pixel = match rectangle_number {
+                        0 => Pixel::new_rgba(255, 127, 0, 255),
+                        1 => Pixel::new_rgba(255, 255, 0, 127),
+                        2 => Pixel::new_rgba(127, 127, 0, 127),
+                        3 => Pixel::new_rgba(255, 127, 0, 127),
+                        4 => Pixel::new_rgba(255, 127, 0, 0),
+                        _ => Pixel::new_rgba(0, 0, 0, 0),
+                    };
+
+                    // Convert `AlphaMode::Opaque` -> `AlphaMode::Ignored`.
+                    if alpha_mode == AlphaMode::Opaque {
+                        pixel.a = 255;
+                    };
+                }
+
+                buffer.present().unwrap();
+            }
+            WindowEvent::CloseRequested
+            | WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key: Key::Named(NamedKey::Escape),
+                        repeat: false,
+                        ..
+                    },
+                ..
+            } => {
+                elwt.exit();
+            }
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key,
+                        repeat: false,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } => {
+                let Some(surface) = surface else {
+                    tracing::error!("KeyboardInput fired before Resumed or after Suspended");
+                    return;
+                };
+
+                let alpha_mode = match logical_key.to_text() {
+                    Some("1") => AlphaMode::Opaque,
+                    Some("2") => AlphaMode::Ignored,
+                    Some("3") => AlphaMode::Premultiplied,
+                    Some("4") => AlphaMode::Postmultiplied,
+                    _ => return,
+                };
+
+                if !surface.supports_alpha_mode(alpha_mode) {
+                    tracing::warn!(?alpha_mode, "not supported by the backend");
+                    return;
+                }
+
+                tracing::info!(?alpha_mode, "set alpha");
+                let size = window.inner_size();
+                let width = NonZeroU32::new(size.width).unwrap();
+                let height = NonZeroU32::new(size.height).unwrap();
+                surface.configure(width, height, alpha_mode).unwrap();
+                assert_eq!(surface.alpha_mode(), alpha_mode);
+
+                window.set_transparent(matches!(
+                    alpha_mode,
+                    AlphaMode::Premultiplied | AlphaMode::Postmultiplied
+                ));
+
+                window.request_redraw();
+            }
+            _ => {}
+        }
+    });
+
+    util::run_app(event_loop, app);
+}

--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -1,6 +1,6 @@
 //! Implements `buffer_interface::*` traits for enums dispatching to backends
 
-use crate::{backend_interface::*, backends, InitError, Pixel, Rect, SoftBufferError};
+use crate::{backend_interface::*, backends, AlphaMode, InitError, Pixel, Rect, SoftBufferError};
 
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::fmt;
@@ -99,20 +99,30 @@ macro_rules! make_dispatch {
                 }
             }
 
-            fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+            #[inline]
+            fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
                 match self {
                     $(
                         $(#[$attr])*
-                        Self::$name(inner) => inner.resize(width, height),
+                        Self::$name(inner) => inner.supports_alpha_mode(alpha_mode),
                     )*
                 }
             }
 
-            fn next_buffer(&mut self) -> Result<BufferDispatch<'_>, SoftBufferError> {
+            fn configure(&mut self, width: NonZeroU32, height: NonZeroU32, alpha_mode: AlphaMode) -> Result<(), SoftBufferError> {
                 match self {
                     $(
                         $(#[$attr])*
-                        Self::$name(inner) => Ok(BufferDispatch::$name(inner.next_buffer()?)),
+                        Self::$name(inner) => inner.configure(width, height, alpha_mode),
+                    )*
+                }
+            }
+
+            fn next_buffer(&mut self, alpha_mode: AlphaMode) -> Result<BufferDispatch<'_>, SoftBufferError> {
+                match self {
+                    $(
+                        $(#[$attr])*
+                        Self::$name(inner) => Ok(BufferDispatch::$name(inner.next_buffer(alpha_mode)?)),
                     )*
                 }
             }

--- a/src/backend_interface.rs
+++ b/src/backend_interface.rs
@@ -1,6 +1,6 @@
 //! Interface implemented by backends
 
-use crate::{InitError, Pixel, Rect, SoftBufferError};
+use crate::{AlphaMode, InitError, Pixel, Rect, SoftBufferError};
 
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::num::NonZeroU32;
@@ -22,12 +22,23 @@ pub(crate) trait SurfaceInterface<D: HasDisplayHandle + ?Sized, W: HasWindowHand
     where
         W: Sized,
         Self: Sized;
+
     /// Get the inner window handle.
     fn window(&self) -> &W;
-    /// Resize the internal buffer to the given width and height.
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError>;
+
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool;
+
+    /// Reconfigure the internal buffer(s).
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError>;
+
     /// Get the next buffer to render into.
-    fn next_buffer(&mut self) -> Result<Self::Buffer<'_>, SoftBufferError>;
+    fn next_buffer(&mut self, alpha_mode: AlphaMode) -> Result<Self::Buffer<'_>, SoftBufferError>;
+
     /// Fetch the buffer from the window.
     fn fetch(&mut self) -> Result<Vec<Pixel>, SoftBufferError> {
         Err(SoftBufferError::Unimplemented)

--- a/src/backends/android.rs
+++ b/src/backends/android.rs
@@ -12,7 +12,7 @@ use raw_window_handle::AndroidNdkWindowHandle;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 
 use crate::error::InitError;
-use crate::{util, BufferInterface, Pixel, Rect, SoftBufferError, SurfaceInterface};
+use crate::{util, AlphaMode, BufferInterface, Pixel, Rect, SoftBufferError, SurfaceInterface};
 
 /// The handle to a window for software buffering.
 #[derive(Debug)]
@@ -52,8 +52,18 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Android
         &self.window
     }
 
-    /// Also changes the pixel format to [`HardwareBufferFormat::R8G8B8A8_UNORM`].
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    #[inline]
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        matches!(alpha_mode, AlphaMode::Opaque | AlphaMode::Ignored)
+    }
+
+    /// Also changes the pixel format.
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
         let (width, height) = (|| {
             let width = NonZeroI32::try_from(width).ok()?;
             let height = NonZeroI32::try_from(height).ok()?;
@@ -61,22 +71,26 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Android
         })()
         .ok_or(SoftBufferError::SizeOutOfRange { width, height })?;
 
+        // Default is typically R5G6B5 16bpp, switch to 32bpp
+        let pixel_format = match alpha_mode {
+            AlphaMode::Opaque | AlphaMode::Ignored => HardwareBufferFormat::R8G8B8X8_UNORM,
+            AlphaMode::Premultiplied => todo!("HardwareBufferFormat::R8G8B8A8_UNORM"),
+            AlphaMode::Postmultiplied => unreachable!("unsupported alpha format"),
+        };
+
         self.native_window
-            .set_buffers_geometry(
-                width.into(),
-                height.into(),
-                // Default is typically R5G6B5 16bpp, switch to 32bpp
-                Some(HardwareBufferFormat::R8G8B8X8_UNORM),
-            )
+            .set_buffers_geometry(width.into(), height.into(), Some(pixel_format))
             .map_err(|err| {
                 SoftBufferError::PlatformError(
                     Some("Failed to set buffer geometry on ANativeWindow".to_owned()),
                     Some(Box::new(err)),
                 )
-            })
+            })?;
+
+        Ok(())
     }
 
-    fn next_buffer(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+    fn next_buffer(&mut self, _alpha_mode: AlphaMode) -> Result<BufferImpl<'_>, SoftBufferError> {
         let native_window_buffer = self.native_window.lock(None).map_err(|err| {
             SoftBufferError::PlatformError(
                 Some("Failed to lock ANativeWindow".to_owned()),

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -1,6 +1,6 @@
 //! Softbuffer implementation using CoreGraphics.
-use crate::backend_interface::*;
 use crate::error::InitError;
+use crate::{backend_interface::*, AlphaMode};
 use crate::{util, Pixel, Rect, SoftBufferError};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Bool};
@@ -225,6 +225,9 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<
         // resized to something that doesn't fit, see #177.
         layer.setContentsGravity(unsafe { kCAGravityTopLeft });
 
+        // Default alpha mode is opaque.
+        layer.setOpaque(true);
+
         // Initialize color space here, to reduce work later on.
         let color_space = CGColorSpace::new_device_rgb().unwrap();
 
@@ -252,19 +255,42 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<
         &self.window_handle
     }
 
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    #[inline]
+    fn supports_alpha_mode(&self, _alpha_mode: AlphaMode) -> bool {
+        true
+    }
+
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
+        let opaque = matches!(alpha_mode, AlphaMode::Opaque | AlphaMode::Ignored);
+        self.layer.setOpaque(opaque);
+        // TODO: Set opaque-ness on root layer too? Is that our responsibility, or Winit's?
+        // self.root_layer.setOpaque(opaque);
+
         self.width = width.get() as usize;
         self.height = height.get() as usize;
         Ok(())
     }
 
-    fn next_buffer(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+    fn next_buffer(&mut self, alpha_mode: AlphaMode) -> Result<BufferImpl<'_>, SoftBufferError> {
         let buffer_size = util::byte_stride(self.width as u32) as usize * self.height / 4;
         Ok(BufferImpl {
             buffer: util::PixelBuffer(vec![Pixel::default(); buffer_size]),
             width: self.width,
             height: self.height,
             color_space: &self.color_space,
+            alpha_info: match (alpha_mode, cfg!(target_endian = "little")) {
+                (AlphaMode::Opaque | AlphaMode::Ignored, true) => CGImageAlphaInfo::NoneSkipFirst,
+                (AlphaMode::Opaque | AlphaMode::Ignored, false) => CGImageAlphaInfo::NoneSkipLast,
+                (AlphaMode::Premultiplied, true) => CGImageAlphaInfo::PremultipliedFirst,
+                (AlphaMode::Premultiplied, false) => CGImageAlphaInfo::PremultipliedLast,
+                (AlphaMode::Postmultiplied, true) => CGImageAlphaInfo::First,
+                (AlphaMode::Postmultiplied, false) => CGImageAlphaInfo::Last,
+            },
             layer: &mut self.layer,
         })
     }
@@ -276,6 +302,7 @@ pub struct BufferImpl<'surface> {
     height: usize,
     color_space: &'surface CGColorSpace,
     buffer: util::PixelBuffer,
+    alpha_info: CGImageAlphaInfo,
     layer: &'surface mut SendCALayer,
 }
 
@@ -331,9 +358,9 @@ impl BufferInterface for BufferImpl<'_> {
         //
         // TODO: Use `CGBitmapInfo::new` once the next version of objc2-core-graphics is released.
         let bitmap_info = CGBitmapInfo(
-            CGImageAlphaInfo::NoneSkipFirst.0
+            self.alpha_info.0
                 | CGImageComponentInfo::Integer.0
-                | CGImageByteOrderInfo::Order32Little.0
+                | CGImageByteOrderInfo::Order32Host.0
                 | CGImagePixelFormatInfo::Packed.0,
         );
 

--- a/src/backends/kms.rs
+++ b/src/backends/kms.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::backend_interface::*;
 use crate::error::{InitError, SoftBufferError, SwResultExt};
-use crate::{util, Pixel};
+use crate::{util, AlphaMode, Pixel};
 
 #[derive(Debug, Clone)]
 struct DrmDevice<'surface> {
@@ -225,7 +225,20 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
         &self.window_handle
     }
 
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    #[inline]
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        matches!(
+            alpha_mode,
+            AlphaMode::Opaque | AlphaMode::Ignored | AlphaMode::Premultiplied
+        )
+    }
+
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
         // Don't resize if we don't have to.
         if let Some(buffer) = &self.buffer {
             let (buffer_width, buffer_height) = buffer.size();
@@ -234,9 +247,15 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
             }
         }
 
+        let format = match alpha_mode {
+            AlphaMode::Opaque | AlphaMode::Ignored => DrmFourcc::Xrgb8888,
+            AlphaMode::Premultiplied => DrmFourcc::Argb8888,
+            AlphaMode::Postmultiplied => unreachable!("unsupported alpha format"),
+        };
+
         // Create a new buffer set.
-        let front_buffer = SharedBuffer::new(&self.display, width, height)?;
-        let back_buffer = SharedBuffer::new(&self.display, width, height)?;
+        let front_buffer = SharedBuffer::new(&self.display, width, height, format)?;
+        let back_buffer = SharedBuffer::new(&self.display, width, height, format)?;
 
         self.buffer = Some(Buffers {
             first_is_front: true,
@@ -252,7 +271,7 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
     }
     */
 
-    fn next_buffer(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+    fn next_buffer(&mut self, _alpha_mode: AlphaMode) -> Result<BufferImpl<'_>, SoftBufferError> {
         // Map the dumb buffer.
         let set = self
             .buffer
@@ -391,10 +410,11 @@ impl SharedBuffer {
         display: &KmsDisplayImpl<D>,
         width: NonZeroU32,
         height: NonZeroU32,
+        format: DrmFourcc,
     ) -> Result<Self, SoftBufferError> {
         let db = display
             .device
-            .create_dumb_buffer((width.get(), height.get()), DrmFourcc::Xrgb8888, 32)
+            .create_dumb_buffer((width.get(), height.get()), format, 32)
             .swbuf_err("failed to create dumb buffer")?;
         let fb = display
             .device

--- a/src/backends/wayland/mod.rs
+++ b/src/backends/wayland/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend_interface::*,
     error::{InitError, SwResultExt},
-    util, Pixel, Rect, SoftBufferError,
+    util, AlphaMode, Pixel, Rect, SoftBufferError,
 };
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
 use std::{
@@ -142,7 +142,20 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
         &self.window_handle
     }
 
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    #[inline]
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        matches!(
+            alpha_mode,
+            AlphaMode::Opaque | AlphaMode::Ignored | AlphaMode::Premultiplied
+        )
+    }
+
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        _alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
         self.size = Some(
             (|| {
                 let width = NonZeroI32::try_from(width).ok()?;
@@ -154,7 +167,15 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
         Ok(())
     }
 
-    fn next_buffer(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+    fn next_buffer(&mut self, alpha_mode: AlphaMode) -> Result<BufferImpl<'_>, SoftBufferError> {
+        // This is documented as `0xXXRRGGBB` on a little-endian machine, which means a byte
+        // order of `[B, G, R, X]`.
+        let format = match alpha_mode {
+            AlphaMode::Opaque | AlphaMode::Ignored => wl_shm::Format::Xrgb8888,
+            AlphaMode::Premultiplied => wl_shm::Format::Argb8888,
+            AlphaMode::Postmultiplied => unreachable!("unsupported alpha format"),
+        };
+
         let (width, height) = self
             .size
             .expect("Must set size of surface before calling `next_buffer()`");
@@ -177,8 +198,8 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
                 }
             }
 
-            // Resize, if buffer isn't large enough
-            back.resize(width.get(), height.get());
+            // Resize if buffer isn't large enough.
+            back.configure(width.get(), height.get(), format);
         } else {
             // Allocate front and back buffer
             self.buffers = Some((
@@ -186,12 +207,14 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
                     &self.display.shm,
                     width.get(),
                     height.get(),
+                    format,
                     &self.display.qh,
                 ),
                 WaylandBuffer::new(
                     &self.display.shm,
                     width.get(),
                     height.get(),
+                    format,
                     &self.display.qh,
                 ),
             ));

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -3,7 +3,7 @@
 //! This module converts the input buffer into a bitmap and then stretches it to the window.
 
 use crate::backend_interface::*;
-use crate::{util, Pixel, Rect, SoftBufferError};
+use crate::{util, AlphaMode, Pixel, Rect, SoftBufferError};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 
 use std::io;
@@ -17,6 +17,7 @@ use std::thread;
 
 use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::Graphics::Gdi;
+use windows_sys::Win32::UI::ColorSystem::LCS_WINDOWS_COLOR_SPACE;
 
 const ZERO_QUAD: Gdi::RGBQUAD = Gdi::RGBQUAD {
     rgbBlue: 0,
@@ -48,24 +49,53 @@ impl Drop for Buffer {
 }
 
 impl Buffer {
-    fn new(window_dc: Gdi::HDC, width: NonZeroI32, height: NonZeroI32) -> Self {
+    fn new(window_dc: Gdi::HDC, width: NonZeroI32, height: NonZeroI32, alpha: bool) -> Self {
         let dc = Allocator::get().allocate(window_dc);
         assert!(!dc.is_null());
 
         // Create a new bitmap info struct.
         let bitmap_info = BitmapInfo {
-            bmi_header: Gdi::BITMAPINFOHEADER {
-                biSize: size_of::<Gdi::BITMAPINFOHEADER>() as u32,
-                biWidth: width.get(),
-                biHeight: -height.get(),
-                biPlanes: 1,
-                biBitCount: 32,
-                biCompression: Gdi::BI_BITFIELDS,
-                biSizeImage: 0,
-                biXPelsPerMeter: 0,
-                biYPelsPerMeter: 0,
-                biClrUsed: 0,
-                biClrImportant: 0,
+            bmi_header: Gdi::BITMAPV5HEADER {
+                bV5Size: size_of::<Gdi::BITMAPV5HEADER>() as u32,
+                bV5Width: width.get(),
+                bV5Height: -height.get(),
+                bV5Planes: 1,
+                bV5BitCount: 32,
+                bV5Compression: Gdi::BI_BITFIELDS,
+                bV5SizeImage: 0,
+                bV5XPelsPerMeter: 0,
+                bV5YPelsPerMeter: 0,
+                bV5ClrUsed: 0,
+                bV5ClrImportant: 0,
+                bV5RedMask: 0x00ff0000,
+                bV5GreenMask: 0x0000ff00,
+                bV5BlueMask: 0x000000ff,
+                bV5AlphaMask: if alpha { 0xff000000 } else { 0x00000000 },
+                bV5CSType: LCS_WINDOWS_COLOR_SPACE as u32,
+                bV5Endpoints: Gdi::CIEXYZTRIPLE {
+                    ciexyzRed: Gdi::CIEXYZ {
+                        ciexyzX: 0,
+                        ciexyzY: 0,
+                        ciexyzZ: 0,
+                    },
+                    ciexyzGreen: Gdi::CIEXYZ {
+                        ciexyzX: 0,
+                        ciexyzY: 0,
+                        ciexyzZ: 0,
+                    },
+                    ciexyzBlue: Gdi::CIEXYZ {
+                        ciexyzX: 0,
+                        ciexyzY: 0,
+                        ciexyzZ: 0,
+                    },
+                },
+                bV5GammaRed: 0,
+                bV5GammaGreen: 0,
+                bV5GammaBlue: 0,
+                bV5Intent: 0,
+                bV5ProfileData: 0,
+                bV5ProfileSize: 0,
+                bV5Reserved: 0,
             },
             bmi_colors: [
                 Gdi::RGBQUAD {
@@ -155,7 +185,7 @@ impl<D: ?Sized, W> Drop for Win32Impl<D, W> {
 /// The Win32-compatible bitmap information.
 #[repr(C)]
 struct BitmapInfo {
-    bmi_header: Gdi::BITMAPINFOHEADER,
+    bmi_header: Gdi::BITMAPV5HEADER,
     bmi_colors: [Gdi::RGBQUAD; 3],
 }
 
@@ -201,7 +231,18 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
         &self.handle
     }
 
-    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    #[inline]
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        // TODO: Support transparency.
+        matches!(alpha_mode, AlphaMode::Opaque | AlphaMode::Ignored)
+    }
+
+    fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
         let (width, height) = (|| {
             let width = NonZeroI32::try_from(width).ok()?;
             let height = NonZeroI32::try_from(height).ok()?;
@@ -215,12 +256,17 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
             }
         }
 
-        self.buffer = Some(Buffer::new(self.dc.0, width, height));
+        let alpha = match alpha_mode {
+            AlphaMode::Opaque | AlphaMode::Ignored => false,
+            AlphaMode::Premultiplied => true,
+            AlphaMode::Postmultiplied => unreachable!("unsupported alpha format"),
+        };
+        self.buffer = Some(Buffer::new(self.dc.0, width, height, alpha));
 
         Ok(())
     }
 
-    fn next_buffer(&mut self) -> Result<BufferImpl<'_>, SoftBufferError> {
+    fn next_buffer(&mut self, _alpha_mode: AlphaMode) -> Result<BufferImpl<'_>, SoftBufferError> {
         let buffer = self
             .buffer
             .as_mut()
@@ -286,6 +332,7 @@ impl BufferInterface for BufferImpl<'_> {
                 let width = util::to_i32_saturating(rect.width.get());
                 let height = util::to_i32_saturating(rect.height.get());
 
+                // TODO: Draw with something else to make transparency work.
                 Gdi::BitBlt(
                     self.dc.0,
                     x,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU32;
 
+use crate::AlphaMode;
+
 #[derive(Debug)]
 #[non_exhaustive]
 /// A sum type of all of the errors that can occur during the operation of this crate.
@@ -86,6 +88,12 @@ pub enum SoftBufferError {
         height: NonZeroU32,
     },
 
+    /// The provided alpha mode is not supported by the backend.
+    UnsupportedAlphaMode {
+        /// The alpha mode that was not supported.
+        alpha_mode: AlphaMode,
+    },
+
     /// A platform-specific backend error occurred.
     ///
     /// The first field provides a human-readable description of the error. The second field
@@ -124,6 +132,10 @@ impl fmt::Display for SoftBufferError {
             Self::SizeOutOfRange { width, height } => write!(
                 f,
                 "Surface size {width}x{height} out of range for backend.",
+            ),
+            Self::UnsupportedAlphaMode { alpha_mode } => write!(
+                f,
+                "Alpha mode {alpha_mode:?} is not supported by the backend.",
             ),
             Self::PlatformError(msg, None) => write!(f, "Platform error: {msg:?}"),
             Self::PlatformError(msg, Some(err)) => write!(f, "Platform error: {msg:?}: {err}"),

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,12 +1,20 @@
 /// A pixel format that Softbuffer may use.
 ///
+/// # Alpha
+///
+/// These pixel formats all include the alpha channel in their name, but formats that ignore the
+/// alpha channel are supported if you set [`AlphaMode::Ignored`]. This will make `RGBA` mean `RGBX`
+/// and `BGRA` mean `BGRX`.
+///
+/// [`AlphaMode::Ignored`]: crate::AlphaMode::Ignored
+///
 /// # Default
 ///
 /// The [`Default::default`] implementation returns the pixel format that Softbuffer uses for the
 /// current target platform.
 ///
-/// Currently, this is [`BGRX`][Self::Bgrx] on all platforms except WebAssembly and Android, where
-/// it is [`RGBX`][Self::Rgbx], since the API on these platforms does not support BGRX.
+/// Currently, this is [`BGRA`][Self::Bgra] on all platforms except WebAssembly and Android, where
+/// it is [`RGBA`][Self::Rgba], since the API on these platforms does not support BGRA.
 ///
 /// The format for a given platform may change in a non-breaking release if found to be more
 /// performant.
@@ -15,16 +23,16 @@
 /// avoid unnecessary copying, see the documentation for [`Pixel`][crate::Pixel] for examples.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 pub enum PixelFormat {
-    /// The pixel format is `RGBX` (red, green, blue, unset).
+    /// The pixel format is `RGBA` (red, green, blue, alpha).
     ///
     /// This is currently the default on macOS/iOS, KMS/DRM, Orbital, Wayland, Windows and X11.
     #[cfg_attr(not(any(target_family = "wasm", target_os = "android")), default)]
-    Bgrx,
-    /// The pixel format is `BGRX` (blue, green, red, unset).
+    Bgra,
+    /// The pixel format is `BGRA` (blue, green, red, alpha).
     ///
     /// This is currently the default on Android and Web.
     #[cfg_attr(any(target_family = "wasm", target_os = "android"), default)]
-    Rgbx,
+    Rgba,
     // Intentionally exhaustive for now.
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub struct Rect {
 pub struct Surface<D, W> {
     /// This is boxed so that `Surface` is the same size on every platform.
     surface_impl: Box<SurfaceDispatch<D, W>>,
+    /// The current alpha mode that the surface is configured with.
+    alpha_mode: AlphaMode,
     _marker: PhantomData<Cell<()>>,
 }
 
@@ -95,6 +97,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
     pub fn new(context: &Context<D>, window: W) -> Result<Self, SoftBufferError> {
         match SurfaceDispatch::new(window, &context.context_impl) {
             Ok(surface_dispatch) => Ok(Self {
+                alpha_mode: AlphaMode::default(),
                 surface_impl: Box::new(surface_dispatch),
                 _marker: PhantomData,
             }),
@@ -115,21 +118,67 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
         self.surface_impl.window()
     }
 
-    /// Set the size of the buffer that will be returned by [`Surface::next_buffer()`].
+    /// The current alpha mode of the surface.
+    #[doc(alias = "transparency")]
+    pub fn alpha_mode(&self) -> AlphaMode {
+        self.alpha_mode
+    }
+
+    /// Set the size of the buffer.
+    ///
+    /// This is a convenience method for reconfiguring when only the size changes, it is equivalent
+    /// to:
+    /// ```ignore
+    /// surface.configure(width, height, surface.alpha_mode());
+    /// ````
+    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+        self.configure(width, height, self.alpha_mode())
+    }
+
+    /// Reconfigure the surface's properties.
+    ///
+    /// This sets the size and alpha mode of the buffer that will be returned by
+    /// [`Surface::next_buffer()`].
     ///
     /// If the size of the buffer does not match the size of the window, the buffer is drawn
     /// in the upper-left corner of the window. It is recommended in most production use cases
     /// to have the buffer fill the entire window. Use your windowing library to find the size
     /// of the window.
-    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
+    //
+    // TODO(madsmtm): What are the exact semantics of configuring? Should it always re-create the
+    // buffers, or should that only be done in `next_buffer` if properties changed?
+    pub fn configure(
+        &mut self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+        alpha_mode: AlphaMode,
+    ) -> Result<(), SoftBufferError> {
         if u32::MAX / 4 < width.get() {
             // Stride would be too large.
             return Err(SoftBufferError::SizeOutOfRange { width, height });
         }
 
-        self.surface_impl.resize(width, height)?;
+        if !self.supports_alpha_mode(alpha_mode) {
+            return Err(SoftBufferError::UnsupportedAlphaMode { alpha_mode });
+        }
+
+        self.surface_impl.configure(width, height, alpha_mode)?;
+
+        self.alpha_mode = alpha_mode;
 
         Ok(())
+    }
+
+    /// Query if the given alpha mode is supported.
+    ///
+    /// See [`AlphaMode`] for documentation on what this will (currently) return on each platform.
+    #[inline]
+    pub fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        // TODO: Once we get pixel formats, replace this with something like:
+        // fn supported_pixel_formats(&self, alpha_mode: AlphaMode) -> &[PixelFormat];
+        //
+        // And return an empty list from that if the alpha mode isn't supported.
+        self.surface_impl.supports_alpha_mode(alpha_mode)
     }
 
     /// Copies the window contents into a buffer.
@@ -144,9 +193,12 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
         self.surface_impl.fetch()
     }
 
-    /// Return a [`Buffer`] that the next frame should be rendered into. The size must
-    /// be set with [`Surface::resize`] first. The initial contents of the buffer may be zeroed, or
-    /// may contain a previous frame. Call [`Buffer::age`] to determine this.
+    /// A [`Buffer`] that the next frame should be rendered into.
+    ///
+    /// The size must be set with [`Surface::resize`] or [`Surface::configure`] first.
+    ///
+    /// The contents of the buffer may be zeroed, or may contain a previous frame. Call
+    /// [`Buffer::age`] to determine this.
     ///
     /// ## Platform Dependent Behavior
     ///
@@ -154,7 +206,9 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
     ///   `softbuffer`. Therefore it is the responsibility of the user to wait for the page flip before
     ///   sending another frame.
     pub fn next_buffer(&mut self) -> Result<Buffer<'_>, SoftBufferError> {
-        let mut buffer_impl = self.surface_impl.next_buffer()?;
+        let alpha_mode = self.alpha_mode();
+
+        let mut buffer_impl = self.surface_impl.next_buffer(alpha_mode)?;
 
         debug_assert_eq!(
             buffer_impl.byte_stride().get() % 4,
@@ -173,6 +227,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> Surface<D, W> {
 
         Ok(Buffer {
             buffer_impl,
+            alpha_mode,
             _marker: PhantomData,
         })
     }
@@ -262,6 +317,7 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> HasWindowHandle for Surface<D, W> 
 #[derive(Debug)]
 pub struct Buffer<'surface> {
     buffer_impl: BufferDispatch<'surface>,
+    alpha_mode: AlphaMode,
     _marker: PhantomData<Cell<()>>,
 }
 
@@ -291,6 +347,11 @@ impl Buffer<'_> {
     /// The amount of pixels tall the buffer is.
     pub fn height(&self) -> NonZeroU32 {
         self.buffer_impl.height()
+    }
+
+    /// The alpha mode that the buffer uses.
+    pub fn alpha_mode(&self) -> AlphaMode {
+        self.alpha_mode
     }
 
     /// `age` is the number of frames ago this buffer was last presented. So if the value is
@@ -339,7 +400,23 @@ impl Buffer<'_> {
     /// - Web
     ///
     /// Otherwise this is equivalent to [`Self::present`].
-    pub fn present_with_damage(self, damage: &[Rect]) -> Result<(), SoftBufferError> {
+    pub fn present_with_damage(mut self, damage: &[Rect]) -> Result<(), SoftBufferError> {
+        // Verify that pixels are set as opaque if the alpha mode requires it.
+        if cfg!(debug_assertions) && self.alpha_mode == AlphaMode::Opaque {
+            // Only check inside `width`, pixels outside are allowed to be anything.
+            let width = self.width().get() as usize;
+            for (y, row) in self.pixel_rows().enumerate() {
+                for (x, pixel) in row.iter().take(width).enumerate() {
+                    let msg = concat!(
+                        "This is required by `AlphaMode::Opaque` for cross-platform support, ",
+                        "either write `0xff` to the alpha channel on all pixels, or use ",
+                        "`AlphaMode::Ignored`."
+                    );
+                    assert_eq!(pixel.a, 0xff, "pixel at ({x}, {y}) was not opaque\n{msg}");
+                }
+            }
+        }
+
         self.buffer_impl.present_with_damage(damage)
     }
 }
@@ -364,7 +441,7 @@ impl Buffer<'_> {
     /// provide a simple API that provides RGBX rendering.
     ///
     /// ```no_run
-    /// use softbuffer::{Pixel, PixelFormat};
+    /// use softbuffer::{AlphaMode, Pixel, PixelFormat};
     ///
     /// // Assume the user controls the following rendering function:
     /// fn render(pixels: &mut [[u8; 4]], width: u32, height: u32) {
@@ -372,21 +449,50 @@ impl Buffer<'_> {
     /// }
     ///
     /// // Then we'd convert pixel data as follows:
+    /// # let surface: softbuffer::Surface<
+    /// #     std::sync::Arc<dyn raw_window_handle::HasDisplayHandle>,
+    /// #     std::sync::Arc<dyn raw_window_handle::HasWindowHandle>,
+    /// # > = todo!();
+    /// # let width = std::num::NonZero::new(1).unwrap();
+    /// # let height = std::num::NonZero::new(1).unwrap();
     ///
-    /// # let buffer: softbuffer::Buffer<'_> = todo!();
-    /// # #[cfg(false)]
-    /// let buffer = surface.next_buffer();
+    /// // At surface creation:
+    /// if surface.supports_alpha_mode(AlphaMode::Ignored) {
+    ///     // Try to use `AlphaMode::Ignored` if possible.
+    ///     surface.configure(width, height, AlphaMode::Ignored);
+    /// } else {
+    ///     // Fall back to `AlphaMode::Opaque` if not.
+    ///     surface.configure(width, height, AlphaMode::Opaque);
+    /// }
+    ///
+    /// // Each draw:
+    /// let buffer = surface.next_buffer().unwrap();
     ///
     /// let width = buffer.width().get();
     /// let height = buffer.height().get();
     ///
-    /// // Use fast, zero-copy implementation when possible, and fall back to slower version when not.
-    /// if PixelFormat::Rgbx.is_default() && buffer.byte_stride().get() == width * 4 {
+    /// if PixelFormat::Rgba.is_default()
+    ///     && buffer.byte_stride().get() == width * 4
+    ///     && buffer.alpha_mode() == AlphaMode::Ignored
+    /// {
+    ///     // Use zero-copy implementation when possible.
+    ///
     ///     // SAFETY: `Pixel` can be reinterpreted as `[u8; 4]`.
     ///     let pixels = unsafe { std::mem::transmute::<&mut [Pixel], &mut [[u8; 4]]>(buffer.pixels()) };
-    ///     // CORRECTNESS: We just checked that the format is RGBX, and that `stride == width * 4`.
+    ///     // CORRECTNESS: We just checked that:
+    ///     // - The format is RGBA.
+    ///     // - The `stride == width * 4`.
+    ///     // - The alpha channel is ignored (A -> X).
+    ///     //
+    ///     // So we can correctly render in the user's expected simplified RGBX format.
     ///     render(pixels, width, height);
     /// } else {
+    ///     // Fall back to slower implementation when zero-copy is not supported.
+    ///     //
+    ///     // Depending on what performance testing says, if the pixel format is the only
+    ///     // incompatibility, you might also want a branch that renders and swizzles the `R` and
+    ///     // `B` channels after user rendering.
+    ///
     ///     // Render into temporary buffer.
     ///     let mut temporary = vec![[0; 4]; width as usize * height as usize];
     ///     render(&mut temporary, width, height);
@@ -516,6 +622,94 @@ impl Buffer<'_> {
                 .enumerate()
                 .map(move |(x, pixel)| (x as u32, y as u32, pixel))
         })
+    }
+}
+
+/// Specifies how the alpha channel of the surface should be handled by the compositor.
+///
+/// See [the WhatWG spec][whatwg-premultiplied] for a good description of the difference between
+/// premultiplied and postmultiplied alpha.
+///
+/// Query [`Surface::supports_alpha_mode`] to figure out supported modes for the current platform /
+/// surface.
+///
+/// [whatwg-premultiplied]: https://html.spec.whatwg.org/multipage/canvas.html#premultiplied-alpha-and-the-2d-rendering-context
+#[doc(alias = "Transparency")]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub enum AlphaMode {
+    /// The alpha channel must be completely opaque (`1.0` or `0xff`).
+    ///
+    /// If it isn't, the alpha channel may be ignored, or the contents may be drawn transparent,
+    /// depending on the platform. Softbuffer contains consistency checks for this internally, so
+    /// using this mode with a transparent alpha channel may panic with `cfg!(debug_assertions)`
+    /// enabled.
+    ///
+    /// **This is the default**, and is supported on all platforms.
+    //
+    // NOTE: We use a separate enum value here instead of just making a platform-specific default,
+    // because even though we'll want to effectively use a `*multiplied` internally on some
+    // platforms, we'll still want to hint to the compositor that the surface is opaque.
+    //
+    // See also <https://github.com/rust-windowing/softbuffer/issues/338>.
+    #[default]
+    Opaque,
+    /// The alpha channel is ignored, and the contents are treated as opaque.
+    ///
+    /// ## Platform Dependent Behavior
+    ///
+    /// - Android, macOS/iOS, DRM/KMS, Orbital, Wayland, Windows, X11: Supported.
+    /// - Web: Cannot be supported in a zero-copy manner.
+    Ignored,
+    /// The non-alpha channels are expected to already have been multiplied by the alpha channel.
+    ///
+    /// ## Platform Dependent Behavior
+    ///
+    /// - Wayland and DRM/KMS: Supported.
+    /// - macOS/iOS: Supported, but currently doesn't work with additive values (maybe only as the
+    ///   root layer?). Will be fixed by <https://github.com/rust-windowing/softbuffer/pull/329>.
+    /// - Web: Not yet supported (TODO `ImageBitmap`).
+    /// - Android, Orbital, Windows and X11: Not supported (yet unknown if they can be, feel
+    ///   free to open an issue about it).
+    #[doc(alias = "Associated")]
+    Premultiplied,
+    /// The non-alpha channels are not expected to already be multiplied by the alpha channel;
+    /// instead, the compositor will multiply the non-alpha channels by the alpha channel during
+    /// compositing.
+    ///
+    /// Also known as "straight alpha".
+    ///
+    /// ## Platform Dependent Behavior
+    ///
+    /// - Web and macOS/iOS: Supported.
+    /// - Android, DRM/KMS, Orbital, Wayland, Windows, X11: Not supported (yet unknown if they can
+    ///   be, feel free to open an issue about it).
+    #[doc(alias = "Straight")]
+    #[doc(alias = "Unassociated")]
+    #[doc(alias = "Unpremultiplied")]
+    Postmultiplied,
+    // Intentionally exhaustive, there are probably no other alpha modes that make sense.
+}
+
+/// Convenience helpers.
+impl AlphaMode {
+    /// Check if this is [`AlphaMode::Opaque`].
+    pub fn is_opaque(self) -> bool {
+        matches!(self, Self::Opaque)
+    }
+
+    /// Check if this is [`AlphaMode::Ignored`].
+    pub fn is_ignored(self) -> bool {
+        matches!(self, Self::Ignored)
+    }
+
+    /// Check if this is [`AlphaMode::Premultiplied`].
+    pub fn is_premultiplied(self) -> bool {
+        matches!(self, Self::Premultiplied)
+    }
+
+    /// Check if this is [`AlphaMode::Postmultiplied`].
+    pub fn is_postmultiplied(self) -> bool {
+        matches!(self, Self::Postmultiplied)
     }
 }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,4 +1,4 @@
-/// A RGBA or BGRA pixel.
+/// A 32-bit pixel with 4 components.
 ///
 /// # Representation
 ///
@@ -8,6 +8,13 @@
 /// type have the same in-memory representation as a `u32`.
 ///
 /// [`PixelFormat::default()`]: crate::PixelFormat#default
+///
+/// # Default
+///
+/// The [`Default`] impl returns a transparent black pixel. Beware that this might not be what you
+/// want if using [`AlphaMode::Opaque`] (which is the default).
+///
+/// [`AlphaMode::Opaque`]: crate::AlphaMode::Opaque
 ///
 /// # Example
 ///
@@ -20,10 +27,10 @@
 /// assert_eq!(red.r, 255);
 /// assert_eq!(red.g, 128);
 /// assert_eq!(red.b, 0);
-/// # // assert_eq!(red.a, 0xff);
-/// #
-/// # // let from_struct_literal = Pixel { r: 255, g: 0x80, b: 0, a: 0xff };
-/// # // assert_eq!(red, from_struct_literal);
+/// assert_eq!(red.a, 0xff);
+///
+/// let from_struct_literal = Pixel { r: 255, g: 0x80, b: 0, a: 0xff };
+/// assert_eq!(red, from_struct_literal);
 /// ```
 ///
 /// Convert a pixel to an array of `u8`s.
@@ -36,8 +43,8 @@
 /// let red = unsafe { core::mem::transmute::<Pixel, [u8; 4]>(red) };
 ///
 /// match PixelFormat::default() {
-///     PixelFormat::Bgrx => assert_eq!(red[2], 255),
-///     PixelFormat::Rgbx => assert_eq!(red[0], 255),
+///     PixelFormat::Bgra => assert_eq!(red[2], 255),
+///     PixelFormat::Rgba => assert_eq!(red[0], 255),
 /// }
 /// ```
 ///
@@ -51,8 +58,8 @@
 /// let red = unsafe { core::mem::transmute::<Pixel, u32>(red) };
 ///
 /// match PixelFormat::default() {
-///     PixelFormat::Bgrx => assert_eq!(red, u32::from_ne_bytes([0x00, 0x00, 0xff, 0x00])),
-///     PixelFormat::Rgbx => assert_eq!(red, u32::from_ne_bytes([0xff, 0x00, 0x00, 0x00])),
+///     PixelFormat::Bgra => assert_eq!(red, u32::from_ne_bytes([0x00, 0x00, 0xff, 0xff])),
+///     PixelFormat::Rgba => assert_eq!(red, u32::from_ne_bytes([0xff, 0x00, 0x00, 0xff])),
 /// }
 /// ```
 #[repr(C)]
@@ -82,14 +89,12 @@ pub struct Pixel {
     ///
     /// `0xff` here means opaque, whereas `0` means transparent.
     ///
-    /// NOTE: Transparency is not yet supported, see [#17], so this doesn't actually do anything.
-    ///
-    /// [#17]: https://github.com/rust-windowing/softbuffer/issues/17
-    pub(crate) a: u8,
+    /// Make sure to set this correctly according to the [`AlphaMode`][crate::AlphaMode].
+    pub a: u8,
 }
 
 impl Pixel {
-    /// Create a new pixel from a red, a green and a blue component.
+    /// Create a new opaque pixel from a red, a green and a blue component.
     ///
     /// # Example
     ///
@@ -100,11 +105,10 @@ impl Pixel {
     /// assert_eq!(red.r, 255);
     /// ```
     pub const fn new_rgb(r: u8, g: u8, b: u8) -> Self {
-        // FIXME(madsmtm): Change alpha to `0xff` once we support transparency.
-        Self { r, g, b, a: 0x00 }
+        Self { r, g, b, a: 0xff }
     }
 
-    /// Create a new pixel from a blue, a green and a red component.
+    /// Create a new opaque pixel from a blue, a green and a red component.
     ///
     /// # Example
     ///
@@ -115,11 +119,38 @@ impl Pixel {
     /// assert_eq!(red.r, 255);
     /// ```
     pub const fn new_bgr(b: u8, g: u8, r: u8) -> Self {
-        // FIXME(madsmtm): Change alpha to `0xff` once we support transparency.
-        Self { r, g, b, a: 0x00 }
+        Self { r, g, b, a: 0xff }
     }
 
-    // TODO(madsmtm): Once we have transparency, add `new_rgba` and `new_bgra` methods.
+    /// Create a new pixel from a red, a green, a blue and an alpha component.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use softbuffer::Pixel;
+    /// #
+    /// let red = Pixel::new_rgba(0xff, 0, 0, 0x7f);
+    /// assert_eq!(red.r, 255);
+    /// assert_eq!(red.a, 127);
+    /// ```
+    pub const fn new_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+
+    /// Create a new pixel from a blue, a green, a red and an alpha component.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use softbuffer::Pixel;
+    /// #
+    /// let red = Pixel::new_bgra(0, 0, 0xff, 0x7f);
+    /// assert_eq!(red.r, 255);
+    /// assert_eq!(red.a, 127);
+    /// ```
+    pub const fn new_bgra(b: u8, g: u8, r: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
 }
 
 // TODO: Implement `Add`/`Mul`/similar `std::ops` like `rgb` does?


### PR DESCRIPTION
Add:

```rust
impl<D, W> Surface<D, W> {
    pub fn alpha_mode(&self) -> AlphaMode { ... }
    pub fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool { ... }

    // `resize` now calls `configure`:
    pub fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) -> Result<(), SoftBufferError> {
        self.configure(width, height, self.alpha_mode())
    }

    pub fn configure(
        &mut self,
        width: NonZeroU32,
        height: NonZeroU32,
        alpha_mode: AlphaMode,
    ) -> Result<(), SoftBufferError> { ... }
}

#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
pub enum AlphaMode {
    #[default]
    Opaque,
    Ignored,
    Premultiplied,
    Postmultiplied,
}
```

This fixes https://github.com/rust-windowing/softbuffer/issues/17 and prepares for https://github.com/rust-windowing/softbuffer/issues/98 / https://github.com/rust-windowing/softbuffer/pull/317.

As noted in the transparency issue, it is important to make a distinction between straight and premultiplied alpha. The former can be easier to work with, but the latter is often what's actually supported by compositors.

One mode that is a bit odd here is `Opaque`, but it's necessary for the Web backend (and IOSurface on macOS/iOS), because that platform doesn't support zero-copy RGBX, the alpha channel is always read (at least from what I could figure out). Adding this mode (and thus requiring that alpha channel to be 255) fixes https://github.com/rust-windowing/softbuffer/issues/207.

The implementation of these modes for each platform is as follows (I have tested all these):
- Android: Transparency doesn't seem to be supported by Winit, so I haven't enabled transparency in Softbuffer yet either (since I couldn't test it).
- CoreGraphics: All right now, will be `Opaque` and `Premultiplied` with `IOSurface`: https://github.com/rust-windowing/softbuffer/pull/329.
- Wayland: `Opaque`, `Ignored`, `Premultiplied`.
- Web: `Opaque` and `Postmultiplied`. `Premultiplied` can be supported in the future with `ImageBitmap` IIUC.
- Win32: I think it could support `Premultiplied`, but I couldn't get it to work properly, so only did part of it, I'm not too familiar with Windows. I suspect it might also need something like https://github.com/rust-windowing/winit/pull/2503.
- X11: Transparency not yet implemented, but pretty sure that `Premultiplied` could be supported.

We _could_ fairly easily implement a conversion step to support postmultiplied alpha when premultiplied is supported by the backend, but I'd like to migrate towards a more efficient design where each backend always do zero-copying, so I haven't done that.

## Expected behaviour

I've created an example `transparency.rs`, which renders a few different shades of orange and yellow. The expected result are as follows:

### `Opaque` / `Ignored`

<img width="900" height="700" alt="opaque" src="https://github.com/user-attachments/assets/13f58dc7-c356-4dd5-a698-89c9982a2501" />

### `Premultiplied`

<img width="900" height="700" alt="premultiplied" src="https://github.com/user-attachments/assets/a550d530-d333-4e65-987c-442a3fe7b565" />

### `Postmultiplied`

<img width="899" height="700" alt="postmultiplied" src="https://github.com/user-attachments/assets/af1146a8-5b51-4846-bd03-2e6d08f03d07" />
