### PR TITLE
Add preceding slash to `shm_open`

### DIFF
--- a/src/backends/wayland/buffer.rs
+++ b/src/backends/wayland/buffer.rs
@@ -37,7 +37,7 @@ fn create_memfile() -> File {
     let mut rng = fastrand::Rng::new();
 
     for _ in 0..=4 {
-        let mut name = String::from("softbuffer-");
+        let mut name = String::from("/softbuffer-");
         name.extend(iter::repeat_with(|| rng.alphanumeric()).take(7));
         name.push('\0');
 

--- a/src/backends/x11.rs
+++ b/src/backends/x11.rs
@@ -791,13 +791,13 @@ fn create_shm_id() -> io::Result<OwnedFd> {
     use posix_shm::{Mode, OFlags};
 
     let mut rng = fastrand::Rng::new();
-    let mut name = String::with_capacity(23);
+    let mut name = String::with_capacity(24);
 
     // Only try four times; the chances of a collision on this space is astronomically low, so if
     // we miss four times in a row we're probably under attack.
     for i in 0..4 {
         name.clear();
-        name.push_str("softbuffer-x11-");
+        name.push_str("/softbuffer-x11-");
         name.extend(std::iter::repeat_with(|| rng.alphanumeric()).take(7));
 
         // Try to create the shared memory segment.


### PR DESCRIPTION
This should improve portability of using this API, as stated in [the man page](https://www.man7.org/linux/man-pages/man3/shm_open.3.html).

Found this while perusing the code, not actually a bug I've hit myself.