### PR TITLE
Add alpha conversion helpers

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,14 @@
+#[inline]
+pub(crate) fn premultiply(val: u8, alpha: u8) -> u8 {
+    // TODO: Do we need to optimize this using bit shifts or similar?
+    ((val as u16 * alpha as u16) / 0xff) as u8
+}
+
+#[inline]
+pub(crate) fn unpremultiply(val: u8, alpha: u8) -> u8 {
+    // TODO: Can we find a cleaner / more efficient way to implement this?
+    (val as u16 * u8::MAX as u16)
+        .checked_div(alpha as u16)
+        .unwrap_or(0)
+        .min(u8::MAX as u16) as u8
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate core;
 mod backend_dispatch;
 mod backend_interface;
 mod backends;
+mod convert;
 mod error;
 mod format;
 mod pixel;
@@ -622,6 +623,76 @@ impl Buffer<'_> {
                 .enumerate()
                 .map(move |(x, pixel)| (x as u32, y as u32, pixel))
         })
+    }
+
+    /// Convert the alpha mode of the buffer in place.
+    ///
+    /// # Examples
+    ///
+    /// Write to the buffer as-if it was [`AlphaMode::Ignored`], and convert afterwards if
+    /// necessary.
+    ///
+    /// ```no_run
+    /// # let buffer: Buffer<'_> = unimplemented!();
+    ///
+    /// surface.supports_alpha_mode(AlphaMode::Ignored) {
+    ///     surface.set_alpha_mode(AlphaMode::Ignored);
+    /// } else {
+    ///     surface.set_alpha_mode(AlphaMode::Opaque);
+    /// }
+    ///
+    /// for row in buffer.pixel_rows() {
+    ///     for pixel in row {
+    ///         // Write red pixels with an arbitrary alpha value.
+    ///         pixel = Pixel::new_rgba(0xff, 0x00, 0x00, 0x7f);
+    ///     }
+    /// }
+    ///
+    /// buffer.make_pixels_opaque();
+    ///
+    /// // Alpha value is ignored, either by compositor () or by us above.
+    /// buffer.present();
+    /// ```
+    #[inline]
+    pub fn make_pixels_opaque(&mut self) {
+        if self.alpha_mode == AlphaMode::Ignored {
+            // Alpha mode is ignored, no need to change the pixels
+            return;
+        }
+        for row in self.pixel_rows() {
+            for pixel in row {
+                // TODO: SIMD-optimize this somehow? Or maybe autovectorization is good enough.
+                pixel.a = 0xff;
+            }
+        }
+    }
+
+    /// Multiply pixel color components by the alpha component.
+    #[inline]
+    pub fn premultiply_pixels(&mut self) {
+        for row in self.pixel_rows() {
+            for pixel in row {
+                // TODO: SIMD-optimize this somehow? Or maybe autovectorization is good enough.
+                let a = pixel.a;
+                pixel.r = convert::premultiply(pixel.r, a);
+                pixel.g = convert::premultiply(pixel.g, a);
+                pixel.b = convert::premultiply(pixel.b, a);
+            }
+        }
+    }
+
+    /// Divide pixel color components by the alpha component.
+    #[inline]
+    pub fn unpremultiply_pixels(&mut self) {
+        for row in self.pixel_rows() {
+            for pixel in row {
+                // TODO: SIMD-optimize this somehow? Or maybe autovectorization is good enough.
+                let a = pixel.a;
+                pixel.r = convert::unpremultiply(pixel.r, a);
+                pixel.g = convert::unpremultiply(pixel.g, a);
+                pixel.b = convert::unpremultiply(pixel.b, a);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Provide a few helper functions for handling the alpha channel when the pixel format of the buffer is `PixelFormat::Bgra8` or `PixelFormat::Rgba8`.

I'm a bit unsure whether it makes sense to provide these? Their current implementations are quite simple, and if we can provide `AlphaMode::Premultiplied` everywhere, the [un-]premultiplication functions probably aren't really necessary. And perhaps the use-case of actually needing `AlphaMode::Ignored` is kinda niche, which makes `make_pixels_opaque` unnecessary too?

---

I think the biggest problem with providing these is that it kinda signals that they're fast implementations, which... They aren't really, they could be made much more performant using SIMD and/or `rayon`.

I know that I don't want Softbuffer to be in the business of providing drawing primitives like `tiny-skia` or `vello_cpu` does, and I guess you could argue that this is kinda in that category, at least in the sense that it's a very different set of things you need to worry about (CPU speed vs. abstracting platform details and managing buffers).