### PR TITLE
Default to RGBX on Windows when debugging assertions are enabled

### DIFF
--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -67,9 +67,12 @@ impl Buffer {
                 biClrUsed: 0,
                 biClrImportant: 0,
             },
+            // debug_assertions -> RGBX order.
+            // not(debug_assertions) -> BGRX order.
             bmi_colors: [
                 Gdi::RGBQUAD {
-                    rgbRed: 0xff,
+                    rgbRed: if cfg!(debug_assertions) { 0xff } else { 0 },
+                    rgbBlue: if cfg!(debug_assertions) { 0 } else { 0xff },
                     ..ZERO_QUAD
                 },
                 Gdi::RGBQUAD {
@@ -77,7 +80,8 @@ impl Buffer {
                     ..ZERO_QUAD
                 },
                 Gdi::RGBQUAD {
-                    rgbBlue: 0xff,
+                    rgbBlue: if cfg!(debug_assertions) { 0xff } else { 0 },
+                    rgbRed: if cfg!(debug_assertions) { 0 } else { 0xff },
                     ..ZERO_QUAD
                 },
             ],

--- a/src/format.rs
+++ b/src/format.rs
@@ -5,11 +5,12 @@
 /// The [`Default::default`] implementation returns the pixel format that Softbuffer uses for the
 /// current target platform.
 ///
-/// Currently, this is [`BGRX`][Self::Bgrx] on all platforms except WebAssembly and Android, where
-/// it is [`RGBX`][Self::Rgbx], since the API on these platforms does not support BGRX.
+/// Currently, this is [BGRX][Self::Bgrx] on all platforms except WebAssembly and Android, where
+/// it is [RGBX][Self::Rgbx], since the API on these platforms does not support BGRX. On Windows,
+/// when debug assertions are enabled, this is RGBX to make it easier to debug issues with assuming
+/// the wrong pixel format.
 ///
-/// The format for a given platform may change in a non-breaking release if found to be more
-/// performant.
+/// The default format for a given platform may change in a non-breaking release.
 ///
 /// This distinction should only be relevant if you're bitcasting `Pixel` to/from a `u32`, to e.g.
 /// avoid unnecessary copying, see the documentation for [`Pixel`][crate::Pixel] for examples.
@@ -17,13 +18,28 @@
 pub enum PixelFormat {
     /// The pixel format is `RGBX` (red, green, blue, unset).
     ///
-    /// This is currently the default on macOS/iOS, KMS/DRM, Orbital, Wayland, Windows and X11.
-    #[cfg_attr(not(any(target_family = "wasm", target_os = "android")), default)]
+    /// This is currently the default on macOS/iOS, KMS/DRM, Orbital, Wayland, X11 and Windows with
+    /// debug assertions disabled.
+    #[cfg_attr(
+        not(any(
+            target_family = "wasm",
+            target_os = "android",
+            all(target_os = "windows", debug_assertions),
+        )),
+        default
+    )]
     Bgrx,
     /// The pixel format is `BGRX` (blue, green, red, unset).
     ///
-    /// This is currently the default on Android and Web.
-    #[cfg_attr(any(target_family = "wasm", target_os = "android"), default)]
+    /// This is currently the default on Android, Web and Windows with debug assertions enabled.
+    #[cfg_attr(
+        any(
+            target_family = "wasm",
+            target_os = "android",
+            all(target_os = "windows", debug_assertions),
+        ),
+        default
+    )]
     Rgbx,
     // Intentionally exhaustive for now.
 }

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -60,10 +60,20 @@
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 pub struct Pixel {
     #[cfg_attr(docsrs, doc(auto_cfg = false))]
-    #[cfg(any(doc, target_family = "wasm", target_os = "android"))]
+    #[cfg(any(
+        doc,
+        target_family = "wasm",
+        target_os = "android",
+        all(target_os = "windows", debug_assertions),
+    ))]
     /// The red component.
     pub r: u8,
-    #[cfg(not(any(doc, target_family = "wasm", target_os = "android")))]
+    #[cfg(not(any(
+        doc,
+        target_family = "wasm",
+        target_os = "android",
+        all(target_os = "windows", debug_assertions),
+    )))]
     /// The blue component.
     pub b: u8,
 
@@ -71,10 +81,20 @@ pub struct Pixel {
     pub g: u8,
 
     #[cfg_attr(docsrs, doc(auto_cfg = false))]
-    #[cfg(any(doc, target_family = "wasm", target_os = "android"))]
+    #[cfg(any(
+        doc,
+        target_family = "wasm",
+        target_os = "android",
+        all(target_os = "windows", debug_assertions),
+    ))]
     /// The blue component.
     pub b: u8,
-    #[cfg(not(any(doc, target_family = "wasm", target_os = "android")))]
+    #[cfg(not(any(
+        doc,
+        target_family = "wasm",
+        target_os = "android",
+        all(target_os = "windows", debug_assertions),
+    )))]
     /// The red component.
     pub r: u8,
 


### PR DESCRIPTION
To help expose issues with assuming the wrong pixel format.

Unsure yet if this is a good idea or not - it does match what I've done in https://github.com/rust-windowing/softbuffer/pull/315 with making the byte stride `debug_assertions`-dependent, but it might also just end up causing more confusion than it helps.

Tested on:
- [ ] Windows
