### PR TITLE
Rename lifetime `Buffer<'a>` to `Buffer<'surface>`

### DIFF
--- a/src/backend_dispatch.rs
+++ b/src/backend_dispatch.rs
@@ -76,7 +76,7 @@ macro_rules! make_dispatch {
 
         impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for SurfaceDispatch<D, W> {
             type Context = ContextDispatch<D>;
-            type Buffer<'a> = BufferDispatch<'a> where Self: 'a;
+            type Buffer<'surface> = BufferDispatch<'surface> where Self: 'surface;
 
             fn new(window: W, display: &Self::Context) -> Result<Self, InitError<W>>
             where
@@ -138,7 +138,7 @@ macro_rules! make_dispatch {
             }
         }
 
-        pub(crate) enum BufferDispatch<'a> {
+        pub(crate) enum BufferDispatch<'surface> {
             $(
                 $(#[$attr])*
                 $name($buffer_inner),
@@ -223,7 +223,7 @@ macro_rules! make_dispatch {
 make_dispatch! {
     <D, W> =>
     #[cfg(target_os = "android")]
-    Android(D, backends::android::AndroidImpl<D, W>, backends::android::BufferImpl<'a>),
+    Android(D, backends::android::AndroidImpl<D, W>, backends::android::BufferImpl<'surface>),
     #[cfg(all(
         feature = "x11",
         not(any(
@@ -234,7 +234,7 @@ make_dispatch! {
             target_os = "windows"
         ))
     ))]
-    X11(std::sync::Arc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'a>),
+    X11(std::sync::Arc<backends::x11::X11DisplayImpl<D>>, backends::x11::X11Impl<D, W>, backends::x11::BufferImpl<'surface>),
     #[cfg(all(
         feature = "wayland",
         not(any(
@@ -245,7 +245,7 @@ make_dispatch! {
             target_os = "windows"
         ))
     ))]
-    Wayland(std::sync::Arc<backends::wayland::WaylandDisplayImpl<D>>, backends::wayland::WaylandImpl<D, W>, backends::wayland::BufferImpl<'a>),
+    Wayland(std::sync::Arc<backends::wayland::WaylandDisplayImpl<D>>, backends::wayland::WaylandImpl<D, W>, backends::wayland::BufferImpl<'surface>),
     #[cfg(all(
         feature = "kms",
         not(any(
@@ -256,13 +256,13 @@ make_dispatch! {
             target_os = "windows"
         ))
     ))]
-    Kms(std::sync::Arc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'a>),
+    Kms(std::sync::Arc<backends::kms::KmsDisplayImpl<D>>, backends::kms::KmsImpl<D, W>, backends::kms::BufferImpl<'surface>),
     #[cfg(target_os = "windows")]
-    Win32(D, backends::win32::Win32Impl<D, W>, backends::win32::BufferImpl<'a>),
+    Win32(D, backends::win32::Win32Impl<D, W>, backends::win32::BufferImpl<'surface>),
     #[cfg(target_vendor = "apple")]
-    CoreGraphics(D, backends::cg::CGImpl<D, W>, backends::cg::BufferImpl<'a>),
+    CoreGraphics(D, backends::cg::CGImpl<D, W>, backends::cg::BufferImpl<'surface>),
     #[cfg(target_family = "wasm")]
-    Web(backends::web::WebDisplayImpl<D>, backends::web::WebImpl<D, W>, backends::web::BufferImpl<'a>),
+    Web(backends::web::WebDisplayImpl<D>, backends::web::WebImpl<D, W>, backends::web::BufferImpl<'surface>),
     #[cfg(target_os = "redox")]
-    Orbital(D, backends::orbital::OrbitalImpl<D, W>, backends::orbital::BufferImpl<'a>),
+    Orbital(D, backends::orbital::OrbitalImpl<D, W>, backends::orbital::BufferImpl<'surface>),
 }

--- a/src/backend_interface.rs
+++ b/src/backend_interface.rs
@@ -14,9 +14,9 @@ pub(crate) trait ContextInterface<D: HasDisplayHandle + ?Sized> {
 
 pub(crate) trait SurfaceInterface<D: HasDisplayHandle + ?Sized, W: HasWindowHandle + ?Sized> {
     type Context: ContextInterface<D>;
-    type Buffer<'a>: BufferInterface
+    type Buffer<'surface>: BufferInterface
     where
-        Self: 'a;
+        Self: 'surface;
 
     fn new(window: W, context: &Self::Context) -> Result<Self, InitError<W>>
     where

--- a/src/backends/android.rs
+++ b/src/backends/android.rs
@@ -24,10 +24,10 @@ pub struct AndroidImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for AndroidImpl<D, W> {
     type Context = D;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     /// Create a new [`AndroidImpl`] from an [`AndroidNdkWindowHandle`].
     fn new(window: W, _display: &Self::Context) -> Result<Self, InitError<W>> {
@@ -115,8 +115,8 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Android
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
-    native_window_buffer: NativeWindowBufferLockGuard<'a>,
+pub struct BufferImpl<'surface> {
+    native_window_buffer: NativeWindowBufferLockGuard<'surface>,
     buffer: util::PixelBuffer,
 }
 

--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -126,10 +126,10 @@ impl<D, W> Drop for CGImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<D, W> {
     type Context = D;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     fn new(window_src: W, _display: &D) -> Result<Self, InitError<W>> {
         // `NSView`/`UIView` can only be accessed from the main thread.
@@ -271,12 +271,12 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
+pub struct BufferImpl<'surface> {
     width: usize,
     height: usize,
-    color_space: &'a CGColorSpace,
+    color_space: &'surface CGColorSpace,
     buffer: util::PixelBuffer,
-    layer: &'a mut SendCALayer,
+    layer: &'surface mut SendCALayer,
 }
 
 impl BufferInterface for BufferImpl<'_> {

--- a/src/backends/kms.rs
+++ b/src/backends/kms.rs
@@ -24,9 +24,9 @@ use crate::error::{InitError, SoftBufferError, SwResultExt};
 use crate::{util, Pixel};
 
 #[derive(Debug, Clone)]
-struct DrmDevice<'a> {
+struct DrmDevice<'surface> {
     /// The underlying raw display file descriptor.
-    fd: BorrowedFd<'a>,
+    fd: BorrowedFd<'surface>,
 }
 
 impl AsFd for DrmDevice<'_> {
@@ -97,9 +97,9 @@ struct Buffers {
 }
 
 /// The buffer implementation.
-pub(crate) struct BufferImpl<'a> {
+pub(crate) struct BufferImpl<'surface> {
     /// The mapping of the dump buffer.
-    mapping: DumbMapping<'a>,
+    mapping: DumbMapping<'surface>,
 
     /// The framebuffer object of the current front buffer.
     front_fb: framebuffer::Handle,
@@ -108,19 +108,19 @@ pub(crate) struct BufferImpl<'a> {
     crtc_handle: crtc::Handle,
 
     /// This is used to change the front buffer.
-    first_is_front: &'a mut bool,
+    first_is_front: &'surface mut bool,
 
     /// The current size.
     size: (NonZeroU32, NonZeroU32),
 
     /// The device file descriptor.
-    device: DrmDevice<'a>,
+    device: DrmDevice<'surface>,
 
     /// Age of the front buffer.
-    front_age: &'a mut u8,
+    front_age: &'surface mut u8,
 
     /// Age of the back buffer.
-    back_age: &'a mut u8,
+    back_age: &'surface mut u8,
 }
 
 impl fmt::Debug for BufferImpl<'_> {
@@ -145,10 +145,10 @@ struct SharedBuffer {
 
 impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> for KmsImpl<D, W> {
     type Context = Arc<KmsDisplayImpl<D>>;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     /// Create a new KMS backend.
     fn new(window: W, display: &Arc<KmsDisplayImpl<D>>) -> Result<Self, InitError<W>> {

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -75,10 +75,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> OrbitalImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for OrbitalImpl<D, W> {
     type Context = D;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     fn new(window: W, _display: &D) -> Result<Self, InitError<W>> {
         let raw = window.window_handle()?.as_raw();
@@ -144,11 +144,11 @@ enum Pixels {
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
+pub struct BufferImpl<'surface> {
     window_fd: usize,
     width: u32,
     height: u32,
-    presented: &'a mut bool,
+    presented: &'surface mut bool,
     pixels: Pixels,
 }
 

--- a/src/backends/wayland/mod.rs
+++ b/src/backends/wayland/mod.rs
@@ -93,10 +93,10 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W>
     for WaylandImpl<D, W>
 {
     type Context = Arc<WaylandDisplayImpl<D>>;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     fn new(window: W, display: &Arc<WaylandDisplayImpl<D>>) -> Result<Self, InitError<W>> {
         // Get the raw Wayland window.
@@ -208,11 +208,11 @@ impl<D: ?Sized, W: ?Sized> Drop for WaylandImpl<D, W> {
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
-    event_queue: &'a Mutex<EventQueue<State>>,
-    surface: &'a wl_surface::WlSurface,
-    front: &'a mut WaylandBuffer,
-    back: &'a mut WaylandBuffer,
+pub struct BufferImpl<'surface> {
+    event_queue: &'surface Mutex<EventQueue<State>>,
+    surface: &'surface wl_surface::WlSurface,
+    front: &'surface mut WaylandBuffer,
+    back: &'surface mut WaylandBuffer,
     width: i32,
     height: i32,
     age: u8,

--- a/src/backends/web.rs
+++ b/src/backends/web.rs
@@ -126,10 +126,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> WebImpl<D, W> {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for WebImpl<D, W> {
     type Context = WebDisplayImpl<D>;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     fn new(window: W, display: &WebDisplayImpl<D>) -> Result<Self, InitError<W>> {
         let raw = window.window_handle()?.as_raw();
@@ -304,10 +304,10 @@ impl Canvas {
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
-    canvas: &'a Canvas,
-    buffer: &'a mut util::PixelBuffer,
-    buffer_presented: &'a mut bool,
+pub struct BufferImpl<'surface> {
+    canvas: &'surface Canvas,
+    buffer: &'surface mut util::PixelBuffer,
+    buffer_presented: &'surface mut bool,
     size: Option<(NonZeroU32, NonZeroU32)>,
 }
 

--- a/src/backends/win32.rs
+++ b/src/backends/win32.rs
@@ -161,10 +161,10 @@ struct BitmapInfo {
 
 impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Impl<D, W> {
     type Context = D;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     /// Create a new `Win32Impl` from a `Win32WindowHandle`.
     fn new(window: W, _display: &D) -> Result<Self, crate::error::InitError<W>> {
@@ -240,10 +240,10 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for Win32Im
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
-    window: &'a OnlyUsedFromOrigin<HWND>,
-    dc: &'a OnlyUsedFromOrigin<Gdi::HDC>,
-    buffer: &'a mut Buffer,
+pub struct BufferImpl<'surface> {
+    window: &'surface OnlyUsedFromOrigin<HWND>,
+    dc: &'surface OnlyUsedFromOrigin<Gdi::HDC>,
+    buffer: &'surface mut Buffer,
 }
 
 impl BufferInterface for BufferImpl<'_> {

--- a/src/backends/x11.rs
+++ b/src/backends/x11.rs
@@ -189,10 +189,10 @@ struct ShmBuffer {
 
 impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> for X11Impl<D, W> {
     type Context = Arc<X11DisplayImpl<D>>;
-    type Buffer<'a>
-        = BufferImpl<'a>
+    type Buffer<'surface>
+        = BufferImpl<'surface>
     where
-        Self: 'a;
+        Self: 'surface;
 
     /// Create a new `X11Impl` from a `HasWindowHandle`.
     fn new(window_src: W, display: &Arc<X11DisplayImpl<D>>) -> Result<Self, InitError<W>> {
@@ -407,14 +407,14 @@ impl<D: HasDisplayHandle + ?Sized, W: HasWindowHandle> SurfaceInterface<D, W> fo
 }
 
 #[derive(Debug)]
-pub struct BufferImpl<'a> {
+pub struct BufferImpl<'surface> {
     // Various fields that reference data in `X11Impl`.
-    connection: &'a XCBConnection,
+    connection: &'surface XCBConnection,
     window: xproto::Window,
     gc: xproto::Gcontext,
     depth: u8,
-    buffer: &'a mut Buffer,
-    buffer_presented: &'a mut bool,
+    buffer: &'surface mut Buffer,
+    buffer_presented: &'surface mut bool,
     size: Option<(NonZeroU16, NonZeroU16)>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> HasWindowHandle for Surface<D, W> 
 /// Buffer copies an channel swizzling happen on:
 /// - Android
 #[derive(Debug)]
-pub struct Buffer<'a> {
-    buffer_impl: BufferDispatch<'a>,
+pub struct Buffer<'surface> {
+    buffer_impl: BufferDispatch<'surface>,
     _marker: PhantomData<Cell<()>>,
 }
 


### PR DESCRIPTION
To make it a bit clearer that the buffer borrows from the surface.