### PR TITLE
Don't report CoreGraphics as supporting premultiplied alpha

### DIFF
--- a/src/backends/cg.rs
+++ b/src/backends/cg.rs
@@ -284,8 +284,12 @@ impl<D: HasDisplayHandle, W: HasWindowHandle> SurfaceInterface<D, W> for CGImpl<
     }
 
     #[inline]
-    fn supports_alpha_mode(&self, _alpha_mode: AlphaMode) -> bool {
-        true
+    fn supports_alpha_mode(&self, alpha_mode: AlphaMode) -> bool {
+        // Premultiplied doesn't seem to work, at least not with transparent windows.
+        matches!(
+            alpha_mode,
+            AlphaMode::Ignored | AlphaMode::Opaque | AlphaMode::Postmultiplied
+        )
     }
 
     fn configure(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,11 +641,10 @@ pub enum AlphaMode {
     /// ## Platform Dependent Behavior
     ///
     /// - Wayland and DRM/KMS: Supported.
-    /// - macOS/iOS: Supported, but currently doesn't work with additive values (maybe only as the
-    ///   root layer?). Will be fixed by <https://github.com/rust-windowing/softbuffer/pull/329>.
     /// - Web: Not yet supported (TODO `ImageBitmap`).
     /// - Android, Orbital, Windows and X11: Not supported (yet unknown if they can be, feel
     ///   free to open an issue about it).
+    /// - macOS/iOS: Not supported (doesn't seem to work with additive values).
     #[doc(alias = "Associated")]
     Premultiplied,
     /// The non-alpha channels are not expected to already be multiplied by the alpha channel;


### PR DESCRIPTION
It doesn't really support it, the alpha value seems to be clamped, see https://github.com/rust-windowing/softbuffer/pull/321#discussion_r2723201879.

I think I added this when I thought we were gonna do https://github.com/rust-windowing/softbuffer/pull/329, but that one is still a ways away, so I don't think it makes sense for us to report a wrong value.