### PR TITLE
orbital: Use libredox for file syscall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,8 @@ web-sys = { version = "0.3.55", features = [
 
 # Orbital dependencies.
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.7"
+redox_syscall = "0.9"
+libredox = "0.1.18"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,6 @@ web-sys = { version = "0.3.55", features = [
 
 # Orbital dependencies.
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.9"
 libredox = "0.1.18"
 
 [package.metadata.docs.rs]

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -194,7 +194,7 @@ impl BufferInterface for BufferImpl<'_> {
         match self.pixels {
             Pixels::Mapping(mapping) => {
                 drop(mapping);
-                syscall::fsync(self.window_fd).expect("failed to sync orbital window");
+                libredox::call::fsync(self.window_fd).expect("failed to sync orbital window");
                 *self.presented = true;
             }
             Pixels::Buffer(buffer) => {
@@ -212,7 +212,7 @@ fn window_size(window_fd: usize) -> (usize, usize) {
     let mut window_height = 0;
 
     let mut buf: [u8; 4096] = [0; 4096];
-    let count = syscall::fpath(window_fd, &mut buf).unwrap();
+    let count = libredox::call::fpath(window_fd, &mut buf).unwrap();
     let path = str::from_utf8(&buf[..count]).unwrap();
     // orbital:/x/y/w/h/t
     let mut parts = path.split('/').skip(3);
@@ -237,7 +237,7 @@ fn set_buffer(
     let (window_width, window_height) = window_size(window_fd);
 
     let Some(urect) = util::union_damage(damage) else {
-        syscall::fsync(window_fd).expect("failed to sync orbital window");
+        libredox::call::fsync(window_fd).expect("failed to sync orbital window");
         return;
     };
 
@@ -272,5 +272,5 @@ fn set_buffer(
     };
 
     // Tell orbital to show the latest window data
-    syscall::write(window_fd, damage_buf.as_bytes()).expect("failed to sync orbital window");
+    libredox::call::write(window_fd, damage_buf.as_bytes()).expect("failed to sync orbital window");
 }

--- a/src/backends/orbital.rs
+++ b/src/backends/orbital.rs
@@ -13,22 +13,24 @@ struct OrbitalMap {
 }
 
 impl OrbitalMap {
-    unsafe fn new(fd: usize, size_unaligned: usize) -> syscall::Result<Self> {
+    unsafe fn new(fd: usize, size_unaligned: usize) -> std::io::Result<Self> {
+        // from redox_syscall
+        const PAGE_SIZE: usize = 4096;
         // Page align size
-        let pages = (size_unaligned + syscall::PAGE_SIZE - 1) / syscall::PAGE_SIZE;
-        let size = pages * syscall::PAGE_SIZE;
+        let pages = (size_unaligned + PAGE_SIZE - 1) / PAGE_SIZE;
+        let size = pages * PAGE_SIZE;
 
         // Map window buffer
         let address = unsafe {
-            syscall::fmap(
+            libredox::call::mmap(libredox::call::MmapArgs {
+                addr: core::ptr::null_mut(),
+                length: size,
+                prot: libredox::flag::PROT_READ | libredox::flag::PROT_WRITE,
+                flags: libredox::flag::MAP_SHARED,
                 fd,
-                &syscall::Map {
-                    offset: 0,
-                    size,
-                    flags: syscall::PROT_READ | syscall::PROT_WRITE | syscall::MAP_SHARED,
-                    address: 0,
-                },
-            )?
+                offset: 0,
+            })?
+            .addr()
         };
 
         Ok(Self {
@@ -47,7 +49,8 @@ impl Drop for OrbitalMap {
     fn drop(&mut self) {
         unsafe {
             // Unmap window buffer on drop
-            syscall::funmap(self.address, self.size).expect("failed to unmap orbital window");
+            libredox::call::munmap(self.address as _, self.size)
+                .expect("failed to unmap orbital window");
         }
     }
 }


### PR DESCRIPTION
This updates orbital implementation use `libredox`, a newer stable library so that Redox can finish the syscall migration. It's already being done with winit.

Tested with running the demo on orbital: [screenshot](https://gitlab.redox-os.org/-/project/26/uploads/8151361f9c2af97366f9f1faf1f1421f/image.png) [repository](https://github.com/willnode/softbuffer/tree/libredox-demo).

Tested on:
- [X] Orbital (tier 3)
